### PR TITLE
Improve merge to automatically merge multi-row parameter grids 

### DIFF
--- a/R/merge.R
+++ b/R/merge.R
@@ -1,42 +1,74 @@
 #' Merge parameter grid values into a parsnip object
-#' 
-#' \pkg{parsnip} contains model objects that have consistent names with 
+#'
+#' \pkg{parsnip} contains model objects that have consistent names with
 #' \pkg{dials}. `merge` can be used to easily update any of the main parameters
-#' in a \pkg{parsnip} model. 
-#' @param x,y A combination of one \pkg{parsnip} model object (that has class 
-#'  `model_spec`) and one parameter grid resulting from `grid_regular` or 
-#'  `grid_random`. As long as this combination is present, the assignment to 
-#'  `x` and `y` isn't restricted. 
-#' @param ... Not currently used. 
-#' @return An updated model object. 
+#' in a \pkg{parsnip} model.
+#' @param x,y A combination of one \pkg{parsnip} model object (that has class
+#'  `model_spec`) and one parameter grid resulting from `grid_regular` or
+#'  `grid_random`. As long as this combination is present, the assignment to
+#'  `x` and `y` isn't restricted.
+#' @param ... Not currently used.
+#' @return A list containing updated model objects.
 #' @importFrom utils getS3method
 #' @export
 merge.model_spec <- function(x, y, ...) {
-  is_model_spec <- c(inherits(x, "model_spec"), inherits(y, "model_spec"))
-  is_param_grid <- c(inherits(x, "param_grid"), inherits(y, "param_grid"))
-  
-  if(
-    sum(is_model_spec) != 1 |
-    sum(is_param_grid) != 1 | 
-    (sum(is_param_grid) + sum(is_param_grid) != 2)
-  ) 
-    stop("`x` and `y` should contain one 'param_grid' object and one ", 
+
+  # x is known to be a model_spec
+  is_param_grid <- inherits(y, "param_grid")
+
+  if(!is_param_grid) {
+    stop("`x` and `y` should contain one 'param_grid' object and one ",
          "'model_spec' object.", call. = FALSE)
-  
-  upd_mth <- try(getS3method("update", class(x)[1]), silent = TRUE)
-  if (inherits(upd_mth, "try-error"))
-    stop("No `update` method for class '", class(x)[1], "'.",  call. = FALSE)
-  
+  }
+
+  actual_model_spec <- class(x)[1]
+
+  upd_mth <- try(getS3method("update", actual_model_spec), silent = TRUE)
+
+  if (inherits(upd_mth, "try-error")) {
+    stop(
+      "No `update` method for class '", actual_model_spec, "'.",
+      call. = FALSE
+    )
+  }
+
   mod_param <- names(x$args)
   param_names <- names(y)
   common <- intersect(mod_param, param_names)
-  if (length(common) == 0)
+
+  if (length(common) == 0) {
     return(x)
-  param <- as.list(y[, common])
-  param$object <- x
-  do.call("update", param )
+  }
+
+  # always return a list for type stability, even if nrow = 1
+  nrow_y <- nrow(y)
+  nrow_seq <- seq_len(nrow_y)
+  spec_list <- rlang::new_list(nrow_y)
+
+  param_obj <- list(object = x)
+
+  spec_list <- purrr::map(nrow_seq, ~{
+
+    param_lst <- as.list(y[.x, common, drop = FALSE])
+    param_lst <- c(param_lst, param_obj)
+    do.call(upd_mth, param_lst)
+
+  })
+
+  spec_list
 }
+
 #' @export
 #' @rdname merge.model_spec
-merge.param_grid <- function(x, y, ...)
+merge.param_grid <- function(x, y, ...) {
+
+  # x is known to be a param_grid
+  is_model_spec <- inherits(y, "model_spec")
+
+  if(!is_model_spec) {
+    stop("`x` and `y` should contain one 'param_grid' object and one ",
+         "'model_spec' object.", call. = FALSE)
+  }
+
   merge.model_spec(y, x, ...)
+}

--- a/man/merge.model_spec.Rd
+++ b/man/merge.model_spec.Rd
@@ -18,7 +18,7 @@
 \item{...}{Not currently used.}
 }
 \value{
-An updated model object.
+A list containing updated model objects.
 }
 \description{
 \pkg{parsnip} contains model objects that have consistent names with


### PR DESCRIPTION
Here is a little motivation for what this can do:

``` r
library(tidyverse)
library(parsnip)
library(dials)

rf_defaults <- rand_forest(mode = "regression", trees = varying())

mtry2 <- range_set(mtry, c(1,5))

grid <- dials::grid_random(trees, mtry2)

# returns a list with all combinations 
merge(rf_defaults, grid)
#> [[1]]
#> Random Forest Model Specification (regression)
#> 
#> Main Arguments:
#>   mtry = 3
#>   trees = 1592
#> 
#> 
#> [[2]]
#> Random Forest Model Specification (regression)
#> 
#> Main Arguments:
#>   mtry = 5
#>   trees = 492
#> 
#> 
#> [[3]]
#> Random Forest Model Specification (regression)
#> 
#> Main Arguments:
#>   mtry = 5
#>   trees = 1654
#> 
#> 
#> [[4]]
#> Random Forest Model Specification (regression)
#> 
#> Main Arguments:
#>   mtry = 1
#>   trees = 480
#> 
#> 
#> [[5]]
#> Random Forest Model Specification (regression)
#> 
#> Main Arguments:
#>   mtry = 4
#>   trees = 1028

# a potential workflow, but ugly
mutate(grid, specs = map2(trees, mtry, ~update(rf_defaults, trees = .x, mtry = .y)))
#> # A tibble: 5 x 3
#>   trees  mtry specs    
#> * <int> <int> <list>   
#> 1  1592     3 <spec[+]>
#> 2   492     5 <spec[+]>
#> 3  1654     5 <spec[+]>
#> 4   480     1 <spec[+]>
#> 5  1028     4 <spec[+]>

# this is pretty clean, even if we are using the `.`
grid %>%
  mutate(
    specs = merge(rf_defaults, .)
  )
#> # A tibble: 5 x 3
#>   trees  mtry specs    
#> * <int> <int> <list>   
#> 1  1592     3 <spec[+]>
#> 2   492     5 <spec[+]>
#> 3  1654     5 <spec[+]>
#> 4   480     1 <spec[+]>
#> 5  1028     4 <spec[+]>
```

Created on 2018-10-10 by the [reprex
package](http://reprex.tidyverse.org) (v0.2.0).