### PR TITLE
Update param_max_tokens upper bound

### DIFF
--- a/R/param_max_tokens.R
+++ b/R/param_max_tokens.R
@@ -6,7 +6,7 @@
 #' @examples
 #' max_tokens()
 #' @export
-max_tokens <- function(range = c(0L, as.integer(10^5)), trans = NULL) {
+max_tokens <- function(range = c(0L, as.integer(10^3)), trans = NULL) {
   new_quant_param(
     type = "integer",
     range = range,


### PR DESCRIPTION
We are going to overshoot too often with 10^5. With diminishing returns I'll suggest having 1000 for the upper bound as a default instead