### PR TITLE
Replace warning() and stop() with rlang::warn() and rlang::abort()

### DIFF
--- a/R/aaa_ranges.R
+++ b/R/aaa_ranges.R
@@ -47,8 +47,8 @@ range_validate <- function(object, range, ukn_ok = TRUE) {
   else
     ""
   if (length(range) != 2)
-    stop(
-      "`range` must have an upper and lower bound. ", ukn_txt, call. = FALSE
+    rlang::abort(
+      paste0("`range` must have an upper and lower bound. ", ukn_txt)
     )
 
   is_unk <- is_unknown(range)
@@ -57,17 +57,16 @@ range_validate <- function(object, range, ukn_ok = TRUE) {
 
   if (!ukn_ok) {
     if (any(is_unk))
-      stop("Cannot validate ranges when they contains 1+ unknown values.",
-           call. = FALSE)
+      rlang::abort("Cannot validate ranges when they contains 1+ unknown values.")
     if (!any(is_num))
-      stop("`range` should be numeric.", call. = FALSE)
+      rlang::abort("`range` should be numeric.")
 
     # TODO check with transform
   } else {
     if (any(is_na[!is_unk]))
-      stop("Value ranges must be non-missing.", ukn_txt, call. = FALSE)
+      rlang::abort("Value ranges must be non-missing.", ukn_txt)
     if (any(!is_num[!is_unk]))
-      stop("Value ranges must be numeric.", ukn_txt, call. = FALSE)
+      rlang::abort("Value ranges must be numeric.", ukn_txt)
   }
   range
 }
@@ -86,7 +85,7 @@ range_get <- function(object, original = TRUE) {
 #' @rdname range_validate
 range_set <- function(object, range) {
   if (length(range) != 2)
-    stop("`range` should have two elements.")
+    rlang::abort("`range` should have two elements.")
   if (inherits(object, "quant_param")) {
     object <-
       new_quant_param(
@@ -99,7 +98,7 @@ range_set <- function(object, range) {
         label = object$label
       )
   } else {
-    stop("`object` should be a 'quant_param' object", call. = FALSE)
+    rlang::abort("`object` should be a 'quant_param' object")
   }
   object
 }

--- a/R/aaa_unknown.R
+++ b/R/aaa_unknown.R
@@ -76,10 +76,10 @@ has_unknowns_val <- function(object) {
 check_for_unknowns <- function(x, label = "") {
   err_txt <- paste0("Unknowns not allowed in `", label, "`.")
   if (length(x) == 1 && is_unknown(x))
-    stop(err_txt, call. = FALSE)
+    rlang::abort(err_txt)
   is_ukn <- map_lgl(x, is_unknown)
   if (any(is_ukn))
-    stop(err_txt, call. = FALSE)
+    rlang::abort(err_txt)
   invisible(TRUE)
 }
 

--- a/R/aaa_values.R
+++ b/R/aaa_values.R
@@ -308,9 +308,9 @@ inv_wrap <- function(x, object) {
 value_set <- function(object, values) {
   check_for_unknowns(values, "value_set")
   if (length(values) == 0)
-    stop("`values` should at least one element.")
+    rlang::abort("`values` should at least one element.")
   if (!inherits(object, "param"))
-    stop("`object` should be a 'param' object", call. = FALSE)
+    rlang::abort("`object` should be a 'param' object")
 
   if (inherits(object, "quant_param")) {
     object <-

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -75,24 +75,26 @@ new_quant_param <- function(
   type <- match.arg(type)
 
   if (!(type %in% c("double", "integer"))) {
-    stop("`type should be either 'double' or 'integer'.", call. = FALSE)
+    rlang::abort("`type should be either 'double' or 'integer'.")
   }
 
 
   range <- as.list(range)
 
   if (length(inclusive) != 2)
-    stop("`inclusive` must have upper and lower values.", all. = FALSE)
+    rlang::abort("`inclusive` must have upper and lower values.")
   if (any(is.na(inclusive)))
-    stop("Boundary descriptors must be non-missing.", call. = FALSE)
+    rlang::abort("Boundary descriptors must be non-missing.")
   if (!is.logical(inclusive))
-    stop("`inclusive` should be logical", call. = FALSE)
+    rlang::abort("`inclusive` should be logical")
 
   if (!is.null(trans)) {
     if (!is.trans(trans))
-      stop(
-        "`trans` must be a 'trans' class object (or NULL). See ",
-        "`?scales::trans_new`.", call. = FALSE
+      rlang::abort(
+        paste0(
+          "`trans` must be a 'trans' class object (or NULL). See ",
+          "`?scales::trans_new`."
+        )
       )
   }
 
@@ -111,13 +113,17 @@ new_quant_param <- function(
     if(all(ok_vals))
       res$values <- values
     else
-      stop("Some values are not valid: ",
-           glue_collapse(
-             values[!ok_vals],
-             sep = ", ",
-             last = " and ",
-             width = min(options()$width - 30, 10)
-           ))
+      rlang::abort(
+        paste0(
+          "Some values are not valid: ",
+          glue_collapse(
+            values[!ok_vals],
+            sep = ", ",
+            last = " and ",
+            width = min(options()$width - 30, 10)
+          )
+        )
+      )
   }
 
   res
@@ -132,11 +138,11 @@ new_qual_param <- function(type = c("character", "logical"), values,
 
   if (type == "logical") {
     if (!is.logical(values))
-      stop("`values` must be logical", call. = FALSE)
+      rlang::abort("`values` must be logical")
   }
   if (type == "character") {
     if (!is.character(values))
-      stop("`values` must be character", call. = FALSE)
+      rlang::abort("`values` must be character")
   }
   if (is_unknown(default))
     default <- values[1]

--- a/R/dplyr-compat-set.R
+++ b/R/dplyr-compat-set.R
@@ -6,20 +6,22 @@ base_classes <- c(class(tibble::tibble()))
 check_new_names <- function(x) {
   parameters_cols <- c('name', 'id', 'source', 'component', 'component_id', 'object')
   if (!all(parameters_cols %in% names(x))) {
-    stop(
-      "A `parameters` object has required columns.\nMissing columns: ",
-      paste0("'", parameters_cols[!parameters_cols %in% names(x)], "'",
-             collapse = ", "),
-      call. = FALSE
+    rlang::abort(
+      paste0(
+        "A `parameters` object has required columns.\nMissing columns: ",
+        paste0("'", parameters_cols[!parameters_cols %in% names(x)], "'",
+               collapse = ", ")
+      )
     )
   }
   extra_names <- names(x)[!names(x) %in% parameters_cols]
   if (length(extra_names) != 0) {
-    warning(
-      "Extra names were added to the `parameters`, which has a specific data ",
-      "structure. These columns will be removed: ",
-      paste0("'", extra_names, "'", collapse = ", "),
-      call. = FALSE
+    rlang::warn(
+      paste0(
+        "Extra names were added to the `parameters`, which has a specific data ",
+        "structure. These columns will be removed: ",
+        paste0("'", extra_names, "'", collapse = ", ")
+      )
     )
   }
   invisible(x)

--- a/R/encode_unit.R
+++ b/R/encode_unit.R
@@ -15,25 +15,25 @@
 #' @export
 encode_unit <- function(x, value, direction, ...) {
   if (!any(direction %in% c("forward", "backward"))) {
-    stop("`direction` should be either 'forward' or 'backward'", call. = FALSE)
+    rlang::abort("`direction` should be either 'forward' or 'backward'")
   }
   UseMethod("encode_unit")
 }
 
 #' @export
 encode_unit.default <- function(x, value, direction, ...) {
-  stop("`x` should be a dials parameter object.", call. = FALSE)
+  rlang::abort("`x` should be a dials parameter object.")
 }
 
 #' @export
 encode_unit.quant_param <- function(x, value, direction, original = TRUE, ...) {
 
   if (has_unknowns(x)) {
-    stop("The parameter object contains unknowns.", call. = FALSE)
+    rlang::abort("The parameter object contains unknowns.")
   }
 
   if (!is.numeric(value) || is.matrix(value)) {
-    stop("`value` should be a numeric vector.", call. = FALSE)
+    rlang::abort("`value` should be a numeric vector.")
   }
 
   param_rng <- x$range$upper - x$range$lower
@@ -45,7 +45,7 @@ encode_unit.quant_param <- function(x, value, direction, original = TRUE, ...) {
 
     compl <- value[!is.na(value)]
     if (any(compl < 0) | any(compl > 1)) {
-      stop("Values should be on [0, 1].", call. = FALSE)
+      rlang::abort("Values should be on [0, 1].")
     }
 
     value <- (value * param_rng) + x$range$lower
@@ -68,7 +68,7 @@ encode_unit.quant_param <- function(x, value, direction, original = TRUE, ...) {
 encode_unit.qual_param <- function(x, value, direction, ...) {
 
   if (has_unknowns(x)) {
-    stop("The parameter object contains unknowns.", call. = FALSE)
+    rlang::abort("The parameter object contains unknowns.")
   }
 
   ref_vals <- x$values
@@ -78,13 +78,13 @@ encode_unit.qual_param <- function(x, value, direction, ...) {
     # convert to [0, 1]
 
     if (!is.character(value) || is.matrix(value)) {
-      stop("`value` should be a character vector.", call. = FALSE)
+      rlang::abort("`value` should be a character vector.")
     }
 
     compl <- value[!is.na(value)]
     if (!all(compl %in% ref_vals)) {
       bad_vals <- compl[!(compl %in% ref_vals)]
-      stop("Some values are not in the reference set of possible values: ",
+      rlang::abort("Some values are not in the reference set of possible values: ",
            paste0("'", unique(bad_vals), "'", collapse = ", "),
            call. = FALSE
       )
@@ -96,11 +96,11 @@ encode_unit.qual_param <- function(x, value, direction, ...) {
 
     compl <- value[!is.na(value)]
     if (any(compl < 0) | any(compl > 1)) {
-      stop("Values should be on [0, 1].", call. = FALSE)
+      rlang::abort("Values should be on [0, 1].")
     }
 
     if (!is.numeric(value) || is.matrix(value)) {
-      stop("`value` should be a numeric vector.", call. = FALSE)
+      rlang::abort("`value` should be a numeric vector.")
     }
 
     ind <- floor(value * (num_lvl - 1)) + 1

--- a/R/finalize.R
+++ b/R/finalize.R
@@ -125,7 +125,7 @@ finalize.parameters <- function(object, x, force = TRUE, ...) {
 #' @rdname finalize
 get_p <- function(object, x, log_vals = FALSE, ...) {
   if (!inherits(object, "param"))
-    stop("`object` should be a 'param' object.", call. = FALSE)
+    rlang::abort("`object` should be a 'param' object.")
 
   rngs <- range_get(object, original = FALSE)
   if (!is_unknown(rngs$upper))
@@ -133,8 +133,7 @@ get_p <- function(object, x, log_vals = FALSE, ...) {
 
   x_dims <- dim(x)
   if (is.null(x_dims))
-    stop("Cannot determine number of columns. Is `x` a 2D data object?",
-         .call = TRUE)
+    rlang::abort("Cannot determine number of columns. Is `x` a 2D data object?")
 
   if (log_vals) {
     rngs[2] <- log10(x_dims[2])
@@ -160,8 +159,7 @@ get_n_frac <- function(object, x, log_vals = FALSE, frac = 1/3, ...) {
 
   x_dims <- dim(x)
   if (is.null(x_dims))
-    stop("Cannot determine number of columns. Is `x` a 2D data object?",
-         .call = TRUE)
+    rlang::abort("Cannot determine number of columns. Is `x` a 2D data object?")
 
   n_frac <- floor(x_dims[1]*frac)
 
@@ -183,8 +181,7 @@ get_n_frac_range <- function(object, x, log_vals = FALSE, frac = c(1/10, 5/10), 
 
   x_dims <- dim(x)
   if (is.null(x_dims))
-    stop("Cannot determine number of columns. Is `x` a 2D data object?",
-         .call = TRUE)
+    rlang::abort("Cannot determine number of columns. Is `x` a 2D data object?")
 
   n_frac <- sort(floor(x_dims[1]*frac))
 
@@ -210,8 +207,7 @@ get_rbf_range <- function(object, x, seed = sample.int(10 ^ 5, 1), ...) {
   suppressPackageStartupMessages(requireNamespace("kernlab", quietly = TRUE))
   x_mat <- as.matrix(x)
   if (!is.numeric(x_mat)) {
-    stop("The matrix version of the initialization data is not numeric.",
-         call. = FALSE)
+    rlang::abort("The matrix version of the initialization data is not numeric.")
   }
   with_seed(seed, rng <- kernlab::sigest(x_mat, ...)[-2])
   rng <- log10(rng)
@@ -227,8 +223,7 @@ get_batch_sizes  <- function(object, x, frac = c(1/10, 1/3), ...) {
 
   x_dims <- dim(x)
   if (is.null(x_dims))
-    stop("Cannot determine number of columns. Is `x` a 2D data object?",
-         .call = TRUE)
+    rlang::abort("Cannot determine number of columns. Is `x` a 2D data object?")
 
   n_frac <- sort(floor(x_dims[1]*frac))
   n_frac <- log2(n_frac)

--- a/R/grids.R
+++ b/R/grids.R
@@ -94,7 +94,9 @@ make_regular_grid <- function(..., levels = 3, original = TRUE) {
   # check levels
   p <- length(levels)
   if (p > 1 && p != length(param_quos))
-    stop("`levels` should have length 1 or ", length(param_quos), call. = FALSE)
+    rlang::abort(
+      paste0("`levels` should have length 1 or ", length(param_quos))
+    )
 
   if (p == 1) {
     param_seq <- map(params, value_seq, n = levels, original = original)

--- a/R/misc.R
+++ b/R/misc.R
@@ -22,10 +22,11 @@ check_installs <- function(x) {
   lib_inst <- rownames(installed.packages())
   is_inst <- x %in% lib_inst
   if (any(!is_inst)) {
-    stop(
-      "Package(s) not installed: ",
-      paste0("'", x[!is_inst], "'", collapse = ", "),
-      call. = FALSE
+    rlang::abort(
+      paste0(
+        "Package(s) not installed: ",
+        paste0("'", x[!is_inst], "'", collapse = ", ")
+      )
     )
   }
 }
@@ -34,19 +35,16 @@ check_installs <- function(x) {
 
 check_label <- function(txt) {
   if (is.null(txt))
-    stop("`label` should be a single named character string or NULL.",
-         call. = FALSE)
+    rlang::abort("`label` should be a single named character string or NULL.")
   if (!is.character(txt) || length(txt) > 1)
-    stop("`label` should be a single named character string or NULL.",
-         call. = FALSE)
+    rlang::abort("`label` should be a single named character string or NULL.")
   if(length(names(txt)) != 1)
-    stop("`label` should be a single named character string or NULL.",
-         call. = FALSE)
+    rlang::abort("`label` should be a single named character string or NULL.")
   invisible(txt)
 }
 
 check_finalize <- function(x) {
   if (!is.null(x) & !is.function(x))
-    stop("`finalize` should be NULL or a function.", .call = FALSE)
+    rlang::abort("`finalize` should be NULL or a function.")
   invisible(x)
 }

--- a/R/param_set.R
+++ b/R/param_set.R
@@ -12,7 +12,7 @@ parameters <- function(x, ...) {
 #' @export
 #' @rdname parameters
 parameters.default <- function(x, ...) {
-  stop("`parameters` objects cannot be created from this type of object.", call. = FALSE)
+  rlang::abort("`parameters` objects cannot be created from this type of object.")
 }
 
 #' @export
@@ -29,7 +29,7 @@ parameters.param <- function(x, ...) {
 parameters.list <- function(x, ...) {
   elem_param <- purrr::map_lgl(x, inherits, "param")
   if (any(!elem_param)) {
-    stop("The objects should all be `param` objects.", call. = FALSE)
+    rlang::abort("The objects should all be `param` objects.")
   }
   elem_name <- purrr::map_chr(x, ~ names(.x$label))
   elem_id <- names(x)
@@ -52,10 +52,14 @@ parameters.list <- function(x, ...) {
 chr_check <- function(x) {
   cl <- match.call()
   if (is.null(x)) {
-    stop("Element `", cl$x, "` should not be NULL.", call. = FALSE)
+    rlang::abort(
+      glue::glue("Element `{cl$x}` should not be NULL.")
+    )
   }
   if (!is.character(x)) {
-    stop("Element `", cl$x, "` should be a character string.", call. = FALSE)
+    rlang::abort(
+      glue::glue("Element `{cl$x}` should be a character string.")
+    )
   }
   invisible(TRUE)
 }
@@ -69,7 +73,7 @@ unique_check <- function(x) {
     msg <- paste0("Element `", deparse(cl$x), "` should have unique values. Duplicates exist ",
                   "for item(s): ",
                   paste0("'", dup_list, "'", collapse = ", "))
-    stop(msg, call. = FALSE)
+    rlang::abort(msg)
   }
   invisible(TRUE)
 }
@@ -96,16 +100,20 @@ parameters_constr <-
     chr_check(component_id)
     unique_check(id)
     if (is.null(object)) {
-      stop("Element `object` should not be NULL.", call. = FALSE)
+      rlang::abort("Element `object` should not be NULL.")
     }
     if (!is.list(object)) {
-      stop("`object` should be a list.", call. = FALSE)
+      rlang::abort("`object` should be a list.")
     }
     is_good_boi <- map_lgl(object, param_or_na)
     if (any(!is_good_boi)) {
-      stop("`object` values in the following positions should be NA or a ",
-           "`param` object:", paste0(which(!is_good_boi), collapse = ", "),
-           call. = FALSE)
+      rlang::abort(
+        paste0(
+          "`object` values in the following positions should be NA or a ",
+          "`param` object:",
+          paste0(which(!is_good_boi), collapse = ", ")
+        )
+      )
     }
     res <-
       tibble(
@@ -239,8 +247,12 @@ update.parameters <- function(object, ...) {
 #' @export
 #' @rdname parameters
 param_set <- function(x, ...) {
-  warning("`param_set()` is deprecated in favor of `parameters()`.",
-          "`param_set()` will be available until version 0.0.5.")
+  rlang::warn(
+    paste0(
+      "`param_set()` is deprecated in favor of `parameters()`. ",
+      "`param_set()` will be available until version 0.0.5."
+    )
+  )
   parameters(x, ...)
 }
 

--- a/R/validation.R
+++ b/R/validation.R
@@ -2,20 +2,25 @@ validate_params <- function(...) {
   param_quos <- quos(...)
   param_expr <- purrr::map_chr(param_quos, rlang::quo_text)
   if (length(param_quos) == 0) {
-    stop("At least one parameter object is required.", call. = FALSE)
+    rlang::abort("At least one parameter object is required.")
   }
   params <- map(param_quos, eval_tidy)
   is_param <- map_lgl(params, function(x) inherits(x, "param"))
   if (!all(is_param)) {
-    stop("These arguments must have class 'param': ",
-         paste0("`", param_expr[!is_param], "`", collapse = ","),
-         call. = FALSE)
+    rlang::abort(
+      paste0(
+        "These arguments must have class 'param': ",
+        paste0("`", param_expr[!is_param], "`", collapse = ",")
+      )
+    )
   }
   bad_param <- has_unknowns(params)
   if (any(bad_param)) {
-    stop("These arguments contains unknowns: ",
-         paste0("`", param_expr[bad_param], "`", collapse = ","),
-         call. = FALSE)
+    rlang::abort(
+      paste0(
+        "These arguments contains unknowns: ",
+        paste0("`", param_expr[bad_param], "`", collapse = ","))
+    )
   }
   invisible(NULL)
 }

--- a/man/Chicago.Rd
+++ b/man/Chicago.Rd
@@ -24,7 +24,7 @@ who enter the Clark and Lake L station.
 The \code{date} column corresponds to the current date. The columns with station
 names (\code{Austin} through \code{California}) are a \emph{sample} of the columns used in
 the original analysis (for file size reasons). These are 14 day lag
-variables (i.e. \verb{date - 14 days}). There are columns related to weather and
+variables (i.e. \code{date - 14 days}). There are columns related to weather and
 sports team schedules.
 
 The station at 35th and Archer is contained in the column \code{Archer_35th} to

--- a/man/finalize.Rd
+++ b/man/finalize.Rd
@@ -28,7 +28,8 @@ get_log_p(object, x, ...)
 
 get_n_frac(object, x, log_vals = FALSE, frac = 1/3, ...)
 
-get_n_frac_range(object, x, log_vals = FALSE, frac = c(1/10, 5/10), ...)
+get_n_frac_range(object, x, log_vals = FALSE, frac = c(1/10, 5/10),
+  ...)
 
 get_n(object, x, log_vals = FALSE, ...)
 
@@ -68,9 +69,9 @@ These functions take a parameter object and modify the unknown parts of
 \details{
 \code{finalize()} runs the embedded finalizer function contained in the \code{param}
 object (\code{object$finalize}) and returns the updated version. The finalization
-function is one of the \verb{get_*()} helpers.
+function is one of the \code{get_*()} helpers.
 
-The \verb{get_*()} helper functions are designed to be used with the pipe
+The \code{get_*()} helper functions are designed to be used with the pipe
 and update the parameter object in-place.
 
 \code{get_p()} and \code{get_log_p()} set the upper value of the range to be

--- a/man/grid_max_entropy.Rd
+++ b/man/grid_max_entropy.Rd
@@ -13,60 +13,32 @@
 \alias{grid_latin_hypercube.workflow}
 \title{Space-filling parameter grids}
 \usage{
-grid_max_entropy(
-  x,
-  ...,
-  size = 3,
-  original = TRUE,
-  variogram_range = 0.5,
-  iter = 1000
-)
+grid_max_entropy(x, ..., size = 3, original = TRUE,
+  variogram_range = 0.5, iter = 1000)
 
-\method{grid_max_entropy}{parameters}(
-  x,
-  ...,
-  size = 3,
-  original = TRUE,
-  variogram_range = 0.5,
-  iter = 1000
-)
+\method{grid_max_entropy}{parameters}(x, ..., size = 3,
+  original = TRUE, variogram_range = 0.5, iter = 1000)
 
-\method{grid_max_entropy}{list}(
-  x,
-  ...,
-  size = 3,
-  original = TRUE,
-  variogram_range = 0.5,
-  iter = 1000
-)
+\method{grid_max_entropy}{list}(x, ..., size = 3, original = TRUE,
+  variogram_range = 0.5, iter = 1000)
 
-\method{grid_max_entropy}{param}(
-  x,
-  ...,
-  size = 3,
-  original = TRUE,
-  variogram_range = 0.5,
-  iter = 1000
-)
+\method{grid_max_entropy}{param}(x, ..., size = 3, original = TRUE,
+  variogram_range = 0.5, iter = 1000)
 
-\method{grid_max_entropy}{workflow}(
-  x,
-  ...,
-  size = 3,
-  original = TRUE,
-  variogram_range = 0.5,
-  iter = 1000
-)
+\method{grid_max_entropy}{workflow}(x, ..., size = 3, original = TRUE,
+  variogram_range = 0.5, iter = 1000)
 
 grid_latin_hypercube(x, ..., size = 3, original = TRUE)
 
-\method{grid_latin_hypercube}{parameters}(x, ..., size = 3, original = TRUE)
+\method{grid_latin_hypercube}{parameters}(x, ..., size = 3,
+  original = TRUE)
 
 \method{grid_latin_hypercube}{list}(x, ..., size = 3, original = TRUE)
 
 \method{grid_latin_hypercube}{param}(x, ..., size = 3, original = TRUE)
 
-\method{grid_latin_hypercube}{workflow}(x, ..., size = 3, original = TRUE)
+\method{grid_latin_hypercube}{workflow}(x, ..., size = 3,
+  original = TRUE)
 }
 \arguments{
 \item{x}{A \code{param} object, list, or \code{parameters}.}

--- a/man/new-param.Rd
+++ b/man/new-param.Rd
@@ -6,24 +6,12 @@
 \alias{new_qual_param}
 \title{Tools for creating new parameter objects}
 \usage{
-new_quant_param(
-  type = c("double", "integer"),
-  range,
-  inclusive,
-  default = unknown(),
-  trans = NULL,
-  values = NULL,
-  label = NULL,
-  finalize = NULL
-)
+new_quant_param(type = c("double", "integer"), range, inclusive,
+  default = unknown(), trans = NULL, values = NULL, label = NULL,
+  finalize = NULL)
 
-new_qual_param(
-  type = c("character", "logical"),
-  values,
-  default = unknown(),
-  label = NULL,
-  finalize = NULL
-)
+new_qual_param(type = c("character", "logical"), values,
+  default = unknown(), label = NULL, finalize = NULL)
 }
 \arguments{
 \item{type}{A single character value. For quantitative parameters, valid

--- a/man/type_sum.param.Rd
+++ b/man/type_sum.param.Rd
@@ -20,9 +20,9 @@ columns.
 For \code{param} objects, the summary prefix is either
 "\code{dparam}" (if a qualitative parameter) or "\code{nparam}" (if
 quantitative). Additionally, brackets are used to indicate if
-there are unknown values. For example, "\verb{nparam[?]}" would
+there are unknown values. For example, "\code{nparam[?]}" would
 indicate that part of the numeric range is has not been
-finalized and "\verb{nparam[+]}" indicates a parameter that is
+finalized and "\code{nparam[+]}" indicates a parameter that is
 complete.
 }
 \keyword{internal}


### PR DESCRIPTION
Closes #84. I mostly used `paste0()` to construct the longer error messages, let me know if you'd prefer `glue()` instead.