### PR TITLE
0.0.5 fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: dials
-Version: 0.0.5
+Version: 0.0.6
 Title: Tools for Creating Tuning Parameter Values
 Description: Many models contain tuning parameters (i.e. parameters that cannot be directly estimated from the data). These tools can be used to define objects for creating, simulating, or validating values for such parameters. 
 Authors@R: c(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dials 0.0.6
+
+* Quick bug fix release related to range checks in 0.0.5. The check is more forgiving when the required type is integer and a double is provided. 
+
 # dials 0.0.5
 
 * When kept in the original units, a parameter's range must now be the same data type as the parameter. 

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -77,11 +77,12 @@ new_quant_param <- function(
   if (!(type %in% c("double", "integer"))) {
     rlang::abort("`type` should be either 'double' or 'integer'.")
   } else {
-    check_range(range, type, trans)
+    range <- check_range(range, type, trans)
   }
 
-
-  range <- as.list(range)
+  if (!is.list(range)) {
+    range <- as.list(range)
+  }
 
   if (length(inclusive) != 2)
     rlang::abort("`inclusive` must have upper and lower values.")

--- a/tests/testthat/test_construction.R
+++ b/tests/testthat/test_construction.R
@@ -70,3 +70,57 @@ test_that('printing', {
   expect_output(print(mtry()))
   expect_output(print(surv_dist()))
 })
+
+
+
+test_that('converting doubles to integers', {
+  expect_equal(
+    typeof(mtry(c(1, unknown()))$range$lower), "integer"
+  )
+  expect_equal(
+    typeof(mtry(c(unknown(), 1))$range$upper), "integer"
+  )
+  expect_equal(
+    typeof(mtry(c(1, 10))$range$lower), "integer"
+  )
+  expect_equal(
+    typeof(mtry(c(1, 10))$range$upper), "integer"
+  )
+})
+
+
+test_that('bad ranges', {
+  expect_error(
+    mixture(c(1L, 3L)),
+    "Since `type = 'double'`, "
+  )
+  expect_error(
+    mixture(c(1L, unknown())),
+    "Since `type = 'double'`, "
+  )
+  expect_error(
+    mixture(c(unknown(), 1L)),
+    "Since `type = 'double'`, "
+  )
+  expect_error(
+    mixture(letters[1:2]),
+    "Since `type = 'double'`, "
+  )
+  expect_error(
+    mtry(c(.1, .5)),
+    "these do not appear to be whole numbers"
+  )
+  expect_error(
+    mtry(c(.1, unknown())),
+    "these do not appear to be whole numbers"
+  )
+  expect_error(
+    mtry(c(unknown(), .5)),
+    "these do not appear to be whole numbers"
+  )
+})
+
+
+
+
+


### PR DESCRIPTION
A bug was introduced in the numeric parameter constructor that affects `parsnip`, `recipes`, and `tune`. The issue didn't show up until the CRAN binaries were built. 

