### PR TITLE
Handle named vector in levels argument of grid_regular

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * `predictor_prop()` was added. 
 
+* The `levels` argument for `tune_grid()` can now handle a named vector, to account for differences in ordering.
+
 ## Breaking changes
 
 * The range of `dist_power()` was changed so that the lower limit is 1. 

--- a/R/grids.R
+++ b/R/grids.R
@@ -10,6 +10,8 @@
 #' @param levels An integer for the number of values of each parameter to use
 #' to make the regular grid. `levels` can be a single integer or a vector of
 #' integers that is the same length as the number of parameters in `...`.
+#' `levels` can be a named integer vector, with names that match the id values
+#' of parameters.
 #'
 #' @param size A single integer for the total number of parameter value
 #' combinations returned for the random grid.
@@ -38,7 +40,8 @@
 #' # grid_regular(mtry(), min_n())
 #'
 #' grid_regular(penalty(), mixture())
-#' grid_regular(penalty(), mixture(), levels = c(3, 4))
+#' grid_regular(penalty(), mixture(), levels = 3:4)
+#' grid_regular(penalty(), mixture(), levels = c(mixture = 4, penalty = 3))
 #' grid_random(penalty(), mixture())
 #'
 #' @export

--- a/R/grids.R
+++ b/R/grids.R
@@ -113,7 +113,7 @@ make_regular_grid <- function(..., levels = 3, original = TRUE, filter = NULL) {
   if (p == 1) {
     param_seq <- map(params, value_seq, n = levels, original = original)
   } else {
-    if (all(has_name(levels, names(params)))) {
+    if (all(rlang::has_name(levels, names(params)))) {
       levels <- levels[names(params)]
     }
     param_seq <- map2(params, as.list(levels), value_seq, original = original)

--- a/R/grids.R
+++ b/R/grids.R
@@ -110,6 +110,9 @@ make_regular_grid <- function(..., levels = 3, original = TRUE, filter = NULL) {
   if (p == 1) {
     param_seq <- map(params, value_seq, n = levels, original = original)
   } else {
+    if (all(has_name(levels, names(params)))) {
+      levels <- levels[names(params)]
+    }
     param_seq <- map2(params, as.list(levels), value_seq, original = original)
   }
 

--- a/R/grids.R
+++ b/R/grids.R
@@ -115,6 +115,8 @@ make_regular_grid <- function(..., levels = 3, original = TRUE, filter = NULL) {
   } else {
     if (all(rlang::has_name(levels, names(params)))) {
       levels <- levels[names(params)]
+    } else if (any(rlang::has_name(levels, names(params)))) {
+      rlang::abort("Elements of `levels` should either be all named or unnamed, not mixed.")
     }
     param_seq <- map2(params, as.list(levels), value_seq, original = original)
   }

--- a/man/grid_regular.Rd
+++ b/man/grid_regular.Rd
@@ -45,7 +45,9 @@ the parameter ranges or values.}
 
 \item{levels}{An integer for the number of values of each parameter to use
 to make the regular grid. \code{levels} can be a single integer or a vector of
-integers that is the same length as the number of parameters in \code{...}.}
+integers that is the same length as the number of parameters in \code{...}.
+\code{levels} can be a named integer vector, with names that match the id values
+of parameters.}
 
 \item{original}{A logical: should the parameters be in the original units or
 in the transformed space (if any)?}
@@ -104,7 +106,8 @@ grid_regular(p, filter = penalty <= .01)
 # grid_regular(mtry(), min_n())
 
 grid_regular(penalty(), mixture())
-grid_regular(penalty(), mixture(), levels = c(3, 4))
+grid_regular(penalty(), mixture(), levels = 3:4)
+grid_regular(penalty(), mixture(), levels = c(mixture = 4, penalty = 3))
 grid_random(penalty(), mixture())
 
 }

--- a/tests/testthat/test_grid.R
+++ b/tests/testthat/test_grid.R
@@ -22,15 +22,19 @@ test_that('regular grid', {
     prod(2:3)
   )
   expect_equal(
-    n_distinct(select(grid_regular(mixture(), trees(),
-                                   levels = c(trees = 2, mixture = 3)),
-                      trees)),
+    dplyr::n_distinct(
+      select(grid_regular(mixture(), trees(),
+                          levels = c(trees = 2, mixture = 3)),
+             trees)
+    ),
     2
   )
   expect_equal(
-    n_distinct(select(grid_regular(mixture(), trees(),
-                                   levels = c(mixture = 3, trees = 2)),
-                      trees)),
+    dplyr::n_distinct(
+      select(grid_regular(mixture(), trees(),
+                          levels = c(mixture = 3, trees = 2)),
+             trees)
+    ),
     2
   )
 })

--- a/tests/testthat/test_grid.R
+++ b/tests/testthat/test_grid.R
@@ -21,6 +21,18 @@ test_that('regular grid', {
     nrow(grid_regular(mixture(), trees(), levels = 2:3)),
     prod(2:3)
   )
+  expect_equal(
+    n_distinct(select(grid_regular(mixture(), trees(),
+                                   levels = c(trees = 2, mixture = 3)),
+                      trees)),
+    2
+  )
+  expect_equal(
+    n_distinct(select(grid_regular(mixture(), trees(),
+                                   levels = c(mixture = 3, trees = 2)),
+                      trees)),
+    2
+  )
 })
 
 test_that('random grid', {


### PR DESCRIPTION
Closes #105.

This PR changes how the `levels` argument handles names; if names exist and match the parameter names, they are matched up before we map across both with `map2()`. There are also two little tests and some updated docs.

The right number of levels now gets assigned to the right parameter, no matter what order they are in the named vector:

``` r
library(tidymodels)
#> ── Attaching packages ───────────────────────────────────────────────────────────────── tidymodels 0.1.0 ──
#> ✓ broom     0.5.6          ✓ recipes   0.1.12    
#> ✓ dials     0.0.6.9000     ✓ rsample   0.0.6     
#> ✓ dplyr     1.0.0          ✓ tibble    3.0.1     
#> ✓ ggplot2   3.3.0          ✓ tune      0.1.0     
#> ✓ infer     0.5.1          ✓ workflows 0.1.1     
#> ✓ parsnip   0.1.1          ✓ yardstick 0.0.6     
#> ✓ purrr     0.3.4
#> ── Conflicts ──────────────────────────────────────────────────────────────────── tidymodels_conflicts() ──
#> x purrr::discard()  masks scales::discard()
#> x dplyr::filter()   masks stats::filter()
#> x dplyr::lag()      masks stats::lag()
#> x ggplot2::margin() masks dials::margin()
#> x recipes::step()   masks stats::step()

rf_spec <- rand_forest(trees = tune(), mtry = tune(), min_n = tune()) %>%
  set_mode("classification") %>%
  set_engine("ranger")

rf_wf <- workflow() %>% 
  add_model(rf_spec)

rf_params <- parameters(rf_wf) %>%
  update(trees = trees(c(100L, 200L))) %>%
  update(mtry = mtry(c(1L, 5L))) %>%
  update(min_n = min_n(c(10L, 20L))) %>%
  finalize()

rf_params$name
#> [1] "mtry"  "trees" "min_n"

levels_vec1 <- c(trees = 3, mtry = 2, min_n = 4)
levels_vec2 <- c(mtry = 2, trees = 3, min_n = 4)
levels_vec3 <- c(min_n = 4, mtry = 2,  trees = 3)

grid_regular(rf_params, levels = levels_vec1)
#> # A tibble: 24 x 3
#>     mtry trees min_n
#>    <int> <int> <int>
#>  1     1   100    10
#>  2     5   100    10
#>  3     1   150    10
#>  4     5   150    10
#>  5     1   200    10
#>  6     5   200    10
#>  7     1   100    13
#>  8     5   100    13
#>  9     1   150    13
#> 10     5   150    13
#> # … with 14 more rows
grid_regular(rf_params, levels = levels_vec2)
#> # A tibble: 24 x 3
#>     mtry trees min_n
#>    <int> <int> <int>
#>  1     1   100    10
#>  2     5   100    10
#>  3     1   150    10
#>  4     5   150    10
#>  5     1   200    10
#>  6     5   200    10
#>  7     1   100    13
#>  8     5   100    13
#>  9     1   150    13
#> 10     5   150    13
#> # … with 14 more rows
grid_regular(rf_params, levels = levels_vec3)
#> # A tibble: 24 x 3
#>     mtry trees min_n
#>    <int> <int> <int>
#>  1     1   100    10
#>  2     5   100    10
#>  3     1   150    10
#>  4     5   150    10
#>  5     1   200    10
#>  6     5   200    10
#>  7     1   100    13
#>  8     5   100    13
#>  9     1   150    13
#> 10     5   150    13
#> # … with 14 more rows
```

<sup>Created on 2020-06-08 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>