### PR TITLE
Remove duplicate rows from parameter grids

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -1,3 +1,9 @@
+# NOTE: This workflow is overkill for most R packages
+# check-standard.yaml is likely a better choice
+# usethis::use_github_action("check-standard") will install it.
+#
+# For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
+# https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
 on:
   push:
     branches:
@@ -18,10 +24,11 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'devel',   dev_dplyr: false}
           - {os: macOS-latest,   r: 'release', dev_dplyr: false}
           - {os: macOS-latest,   r: 'release', dev_dplyr: true}
           - {os: windows-latest, r: 'release'}
+          - {os: windows-latest, r: '3.6'}
+          - {os: ubuntu-16.04,   r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest", http-user-agent: "R/4.0.0 (ubuntu-16.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions" }
           - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
@@ -39,6 +46,7 @@ jobs:
       - uses: r-lib/actions/setup-r@master
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - uses: r-lib/actions/setup-pandoc@master
 
@@ -59,12 +67,11 @@ jobs:
 
       - name: Install system dependencies
         if: runner.os == 'Linux'
-        env:
-          RHUB_PLATFORM: linux-x86_64-ubuntu-gcc
         run: |
-          Rscript -e "remotes::install_github('r-hub/sysreqs')"
-          sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
-          sudo -s eval "$sysreqs"
+          while read -r cmd
+          do
+            eval sudo $cmd
+          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "16.04"))')
 
       - name: Install dependencies
         run: |
@@ -98,7 +105,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@main
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -32,7 +32,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          install.packages("remotes")
           remotes::install_deps(dependencies = TRUE)
           remotes::install_dev("pkgdown")
           remotes::install_github("tidyverse/tidytemplate")
@@ -42,5 +41,7 @@ jobs:
         run: R CMD INSTALL .
 
       - name: Deploy package
-        run: pkgdown::deploy_to_branch(new_process = FALSE)
-        shell: Rscript {0}
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -21,6 +21,8 @@ jobs:
         run: Rscript -e 'roxygen2::roxygenise()'
       - name: commit
         run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
           git add man/\* NAMESPACE
           git commit -m 'Document'
       - uses: r-lib/actions/pr-push@master
@@ -44,6 +46,8 @@ jobs:
         run: Rscript -e 'styler::style_pkg()'
       - name: commit
         run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
           git add \*.R
           git commit -m 'Style'
       - uses: r-lib/actions/pr-push@master

--- a/R/grids.R
+++ b/R/grids.R
@@ -209,6 +209,7 @@ new_param_grid <- function(x = new_data_frame()) {
     rlang::abort("`x` must be a data frame to construct a new grid from.")
   }
 
+  x <- x[vec_unique_loc(x),]
   size <- vec_size(x)
 
   # Strip down to a named list with no extra attributes. This serves

--- a/tests/testthat/test_grid.R
+++ b/tests/testthat/test_grid.R
@@ -50,6 +50,10 @@ test_that('random grid', {
     nrow(grid_random(mixture(), trees(), size = 2)),
     2
   )
+  expect_lt(
+    nrow(grid_random(prod_degree(), prune_method(), size = 10)),
+    10
+  )
 })
 
 

--- a/tests/testthat/test_space_filling.R
+++ b/tests/testthat/test_space_filling.R
@@ -76,8 +76,8 @@ test_that('latin square designs', {
   expect_equal(ncol(grid_3), 1L)
 
   expect_lt(
-    nrow(grid_latin_hypercube(prod_degree(), prune_method(), size = 10)),
-    10
+    nrow(grid_latin_hypercube(prod_degree(), prune_method(), size = 20)),
+    20
   )
 
   expect_error(

--- a/tests/testthat/test_space_filling.R
+++ b/tests/testthat/test_space_filling.R
@@ -75,6 +75,11 @@ test_that('latin square designs', {
   )
   expect_equal(ncol(grid_3), 1L)
 
+  expect_lt(
+    nrow(grid_latin_hypercube(prod_degree(), prune_method(), size = 10)),
+    10
+  )
+
   expect_error(
     grid_latin_hypercube(
       cost,


### PR DESCRIPTION
This PR closes #133 and is related to tidymodels/tune#270.

``` r
library(dials)
#> Loading required package: scales

grid_latin_hypercube(
  prod_degree(),
  prune_method(),
  size = 100
)
#> # A tibble: 12 x 2
#>    prod_degree prune_method
#>          <int> <chr>       
#>  1           2 seqrep      
#>  2           1 backward    
#>  3           2 cv          
#>  4           1 cv          
#>  5           1 none        
#>  6           2 forward     
#>  7           2 none        
#>  8           1 seqrep      
#>  9           1 exhaustive  
#> 10           2 backward    
#> 11           1 forward     
#> 12           2 exhaustive
```

<sup>Created on 2020-09-04 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

Here in dials, this PR currently does _not_ issue a warning that fewer rows are returned that were specified (this is different behavior than in tune). I noticed that this is the existing behavior for `grid_regular()` so I matched it:

> This also means that if n is larger than the range of the integers, a smaller set will be generated.

We can definitely generate a warning, but then folks will get a warning in one situation and not in others. I do think we should add something in the documentation, probably to the `size` argument. Sound good?