### PR TITLE
1D data frames with new_param_grid()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: dials
-Version: 0.0.8.9000
+Version: 0.0.8.9001
 Title: Tools for Creating Tuning Parameter Values
 Description: Many models contain tuning parameters (i.e. parameters that cannot be directly estimated from the data). These tools can be used to define objects for creating, simulating, or validating values for such parameters. 
 Authors@R: c(

--- a/R/grids.R
+++ b/R/grids.R
@@ -209,6 +209,9 @@ new_param_grid <- function(x = new_data_frame()) {
   if (!is.data.frame(x)) {
     rlang::abort("`x` must be a data frame to construct a new grid from.")
   }
+  if (!tibble::is_tibble(x)) {
+    x <- tibble::as_tibble(x)
+  }
 
   x <- x[vec_unique_loc(x),]
   size <- vec_size(x)

--- a/tests/testthat/test_grid.R
+++ b/tests/testthat/test_grid.R
@@ -92,3 +92,12 @@ test_that('filter arg yields same results', {
     with_seed(36L, grid_random(p, filter = mixture == .01))
   )
 })
+
+
+test_that('new param grid from conventional data frame', {
+ x <- data.frame(num_comp = 1:3)
+
+ expect_error(y <- dials:::new_param_grid(x), regexp = NA)
+ expect_true(tibble::is_tibble(y))
+})
+


### PR DESCRIPTION
A change in #139 induced an error since the addition of 

```r
x <- x[vec_unique_loc(x),]
```

fails when `x` is a data frame with one column. 