### PR TITLE
remove `make_regular_grid()` from pkgdown site

### DIFF
--- a/R/grids.R
+++ b/R/grids.R
@@ -95,7 +95,6 @@ grid_regular.workflow <- function(x, ..., levels = 3, original = TRUE, filter = 
   grid_regular.parameters(parameters(x), ..., levels = levels, original = original, filter = {{filter}})
 }
 
-#' @rdname grid_regular
 make_regular_grid <- function(..., levels = 3, original = TRUE, filter = NULL) {
   validate_params(...)
   filter_quo <- enquo(filter)

--- a/man/grid_max_entropy.Rd
+++ b/man/grid_max_entropy.Rd
@@ -101,11 +101,11 @@ parameter space.
 
 Note that there may a difference in grids depending on how the function
 is called. If the call uses the parameter objects directly the possible
-ranges come from the objects in \code{dials}. For example:\if{html}{\out{<div class="r">}}\preformatted{cost()
+ranges come from the objects in \code{dials}. For example:\if{html}{\out{<div class="sourceCode r">}}\preformatted{cost()
 }\if{html}{\out{</div>}}\preformatted{## Cost  (quantitative)
 ## Transformer:  log-2 
 ## Range (transformed scale): [-10, -1]
-}\if{html}{\out{<div class="r">}}\preformatted{set.seed(283)
+}\if{html}{\out{<div class="sourceCode r">}}\preformatted{set.seed(283)
 cost_grid_1 <- grid_latin_hypercube(cost(), size = 1000)
 range(log2(cost_grid_1$cost))
 }\if{html}{\out{</div>}}\preformatted{## [1] -9.998623 -1.000423
@@ -115,7 +115,7 @@ However, in some cases, the \code{tune} package overrides the default ranges
 for specific models. If the grid function uses a \code{parameters} object
 created from a model or recipe, the ranges my have different defaults
 (specific to those models). Using the example above, the \code{cost} argument
-above is different for SVM models:\if{html}{\out{<div class="r">}}\preformatted{library(parsnip)
+above is different for SVM models:\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(parsnip)
 library(tune)
 
 # When used in tune, the log2 range is [-10, 5]

--- a/man/grid_regular.Rd
+++ b/man/grid_regular.Rd
@@ -6,7 +6,6 @@
 \alias{grid_regular.list}
 \alias{grid_regular.param}
 \alias{grid_regular.workflow}
-\alias{make_regular_grid}
 \alias{grid_random}
 \alias{grid_random.parameters}
 \alias{grid_random.list}
@@ -23,8 +22,6 @@ grid_regular(x, ..., levels = 3, original = TRUE, filter = NULL)
 \method{grid_regular}{param}(x, ..., levels = 3, original = TRUE, filter = NULL)
 
 \method{grid_regular}{workflow}(x, ..., levels = 3, original = TRUE, filter = NULL)
-
-make_regular_grid(..., levels = 3, original = TRUE, filter = NULL)
 
 grid_random(x, ..., size = 5, original = TRUE, filter = NULL)
 
@@ -70,10 +67,10 @@ Random and regular grids can be created for any number of parameter objects.
 \details{
 Note that there may a difference in grids depending on how the function
 is called. If the call uses the parameter objects directly the possible
-ranges come from the objects in \code{dials}. For example:\if{html}{\out{<div class="r">}}\preformatted{mixture()
+ranges come from the objects in \code{dials}. For example:\if{html}{\out{<div class="sourceCode r">}}\preformatted{mixture()
 }\if{html}{\out{</div>}}\preformatted{## Proportion of Lasso Penalty (quantitative)
 ## Range: [0, 1]
-}\if{html}{\out{<div class="r">}}\preformatted{set.seed(283)
+}\if{html}{\out{<div class="sourceCode r">}}\preformatted{set.seed(283)
 mix_grid_1 <- grid_random(mixture(), size = 1000)
 range(mix_grid_1$mixture)
 }\if{html}{\out{</div>}}\preformatted{## [1] 0.001490161 0.999741096
@@ -83,7 +80,7 @@ However, in some cases, the \code{tune} package overrides the default ranges
 for specific models. If the grid function uses a \code{parameters} object
 created from a model or recipe, the ranges my have different defaults
 (specific to those models). Using the example above, the \code{mixture}
-argument above is different for \code{glmnet} models:\if{html}{\out{<div class="r">}}\preformatted{library(parsnip)
+argument above is different for \code{glmnet} models:\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(parsnip)
 library(tune)
 
 # When used with glmnet, the range is [0.05, 1.00]


### PR DESCRIPTION
`make_regular_grid()` is not exported, neither are the other `make_*_grid()` functions, yet it showed up on the pkgdown site and the documentation.