### PR TITLE
Doc update to use `extract_parameter_set_dials()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,4 +45,4 @@ Config/Needs/website:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.1.2.9000

--- a/man/grid_max_entropy.Rd
+++ b/man/grid_max_entropy.Rd
@@ -101,32 +101,32 @@ parameter space.
 
 Note that there may a difference in grids depending on how the function
 is called. If the call uses the parameter objects directly the possible
-ranges come from the objects in \code{dials}. For example:\if{html}{\out{<div class="sourceCode r">}}\preformatted{cost()
-}\if{html}{\out{</div>}}\preformatted{## Cost  (quantitative)
-## Transformer:  log-2 
-## Range (transformed scale): [-10, -1]
+ranges come from the objects in \code{dials}. For example:\if{html}{\out{<div class="sourceCode r">}}\preformatted{mixture()
+}\if{html}{\out{</div>}}\preformatted{## Proportion of Lasso Penalty (quantitative)
+## Range: [0, 1]
 }\if{html}{\out{<div class="sourceCode r">}}\preformatted{set.seed(283)
-cost_grid_1 <- grid_latin_hypercube(cost(), size = 1000)
-range(log2(cost_grid_1$cost))
-}\if{html}{\out{</div>}}\preformatted{## [1] -9.998623 -1.000423
+mix_grid_1 <- grid_latin_hypercube(mixture(), size = 1000)
+range(mix_grid_1$mixture)
+}\if{html}{\out{</div>}}\preformatted{## [1] 0.0001530482 0.9999530388
 }
 
-However, in some cases, the \code{tune} package overrides the default ranges
-for specific models. If the grid function uses a \code{parameters} object
-created from a model or recipe, the ranges my have different defaults
-(specific to those models). Using the example above, the \code{cost} argument
-above is different for SVM models:\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(parsnip)
+However, in some cases, the \code{parsnip} and \code{recipe} packages overrides
+the default ranges for specific models and preprocessing steps. If the
+grid function uses a \code{parameters} object created from a model or recipe,
+the ranges may have different defaults (specific to those models). Using
+the example above, the \code{mixture} argument above is different for
+\code{glmnet} models:\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(parsnip)
 library(tune)
 
-# When used in tune, the log2 range is [-10, 5]
-svm_mod <-
-  svm_rbf(cost = tune()) \%>\%
-  set_engine("kernlab")
+# When used with glmnet, the range is [0.05, 1.00]
+glmn_mod <-
+  linear_reg(mixture = tune()) \%>\%
+  set_engine("glmnet")
 
 set.seed(283)
-cost_grid_2 <- grid_latin_hypercube(parameters(svm_mod), size = 1000)
-range(log2(cost_grid_2$cost))
-}\if{html}{\out{</div>}}\preformatted{## [1] -9.997704  4.999296
+mix_grid_2 <- grid_latin_hypercube(extract_parameter_set_dials(glmn_mod), size = 1000)
+range(mix_grid_2$mixture)
+}\if{html}{\out{</div>}}\preformatted{## [1] 0.0501454 0.9999554
 }
 }
 \examples{

--- a/man/grid_regular.Rd
+++ b/man/grid_regular.Rd
@@ -76,11 +76,12 @@ range(mix_grid_1$mixture)
 }\if{html}{\out{</div>}}\preformatted{## [1] 0.001490161 0.999741096
 }
 
-However, in some cases, the \code{tune} package overrides the default ranges
-for specific models. If the grid function uses a \code{parameters} object
-created from a model or recipe, the ranges my have different defaults
-(specific to those models). Using the example above, the \code{mixture}
-argument above is different for \code{glmnet} models:\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(parsnip)
+However, in some cases, the \code{parsnip} and \code{recipe} packages overrides
+the default ranges for specific models and preprocessing steps. If the
+grid function uses a \code{parameters} object created from a model or recipe,
+the ranges may have different defaults (specific to those models). Using
+the example above, the \code{mixture} argument above is different for
+\code{glmnet} models:\if{html}{\out{<div class="sourceCode r">}}\preformatted{library(parsnip)
 library(tune)
 
 # When used with glmnet, the range is [0.05, 1.00]
@@ -89,7 +90,7 @@ glmn_mod <-
   set_engine("glmnet")
 
 set.seed(283)
-mix_grid_2 <- grid_random(parameters(glmn_mod), size = 1000)
+mix_grid_2 <- grid_random(extract_parameter_set_dials(glmn_mod), size = 1000)
 range(mix_grid_2$mixture)
 }\if{html}{\out{</div>}}\preformatted{## [1] 0.05141565 0.99975404
 }

--- a/man/rmd/rand_notes.Rmd
+++ b/man/rmd/rand_notes.Rmd
@@ -12,7 +12,7 @@ mix_grid_1 <- grid_random(mixture(), size = 1000)
 range(mix_grid_1$mixture)
 ```
 
-However, in some cases, the `tune` package overrides the default ranges for specific models. If the grid function uses a `parameters` object created from a model or recipe, the ranges my have different defaults (specific to those models). Using the example above, the `mixture` argument above is different for `glmnet` models: 
+However, in some cases, the `parsnip` and `recipe` packages overrides the default ranges for specific models and preprocessing steps. If the grid function uses a `parameters` object created from a model or recipe, the ranges may have different defaults (specific to those models). Using the example above, the `mixture` argument above is different for `glmnet` models: 
  
 ```{r rand-from-parsnip}
 library(parsnip)
@@ -24,6 +24,6 @@ glmn_mod <-
   set_engine("glmnet")
 
 set.seed(283)
-mix_grid_2 <- grid_random(parameters(glmn_mod), size = 1000)
+mix_grid_2 <- grid_random(extract_parameter_set_dials(glmn_mod), size = 1000)
 range(mix_grid_2$mixture)
 ```

--- a/man/rmd/rand_notes.md
+++ b/man/rmd/rand_notes.md
@@ -22,7 +22,7 @@ range(mix_grid_1$mixture)
 ## [1] 0.001490161 0.999741096
 ```
 
-However, in some cases, the `tune` package overrides the default ranges for specific models. If the grid function uses a `parameters` object created from a model or recipe, the ranges my have different defaults (specific to those models). Using the example above, the `mixture` argument above is different for `glmnet` models: 
+However, in some cases, the `parsnip` and `recipe` packages overrides the default ranges for specific models and preprocessing steps. If the grid function uses a `parameters` object created from a model or recipe, the ranges may have different defaults (specific to those models). Using the example above, the `mixture` argument above is different for `glmnet` models: 
  
 
 ```r
@@ -35,7 +35,7 @@ glmn_mod <-
   set_engine("glmnet")
 
 set.seed(283)
-mix_grid_2 <- grid_random(parameters(glmn_mod), size = 1000)
+mix_grid_2 <- grid_random(extract_parameter_set_dials(glmn_mod), size = 1000)
 range(mix_grid_2$mixture)
 ```
 

--- a/man/rmd/sfd_notes.Rmd
+++ b/man/rmd/sfd_notes.Rmd
@@ -5,25 +5,25 @@ library(tidymodels)
 Note that there may a difference in grids depending on how the function is called. If the call uses the parameter objects directly the possible ranges come from the objects in `dials`. For example: 
 
 ```{r sfd-from-dials}
-cost()
+mixture()
 
 set.seed(283)
-cost_grid_1 <- grid_latin_hypercube(cost(), size = 1000)
-range(log2(cost_grid_1$cost))
+mix_grid_1 <- grid_latin_hypercube(mixture(), size = 1000)
+range(mix_grid_1$mixture)
 ```
 
-However, in some cases, the `tune` package overrides the default ranges for specific models. If the grid function uses a `parameters` object created from a model or recipe, the ranges my have different defaults (specific to those models). Using the example above, the `cost` argument above is different for SVM models: 
-  
+However, in some cases, the `parsnip` and `recipe` packages overrides the default ranges for specific models and preprocessing steps. If the grid function uses a `parameters` object created from a model or recipe, the ranges may have different defaults (specific to those models). Using the example above, the `mixture` argument above is different for `glmnet` models: 
+
 ```{r sfd-from-parsnip}
 library(parsnip)
 library(tune)
 
-# When used in tune, the log2 range is [-10, 5]
-svm_mod <-
-  svm_rbf(cost = tune()) %>%
-  set_engine("kernlab")
+# When used with glmnet, the range is [0.05, 1.00]
+glmn_mod <-
+  linear_reg(mixture = tune()) %>%
+  set_engine("glmnet")
 
 set.seed(283)
-cost_grid_2 <- grid_latin_hypercube(parameters(svm_mod), size = 1000)
-range(log2(cost_grid_2$cost))
+mix_grid_2 <- grid_latin_hypercube(extract_parameter_set_dials(glmn_mod), size = 1000)
+range(mix_grid_2$mixture)
 ```

--- a/man/rmd/sfd_notes.md
+++ b/man/rmd/sfd_notes.md
@@ -4,42 +4,41 @@ Note that there may a difference in grids depending on how the function is calle
 
 
 ```r
-cost()
+mixture()
 ```
 
 ```
-## Cost  (quantitative)
-## Transformer:  log-2 
-## Range (transformed scale): [-10, -1]
+## Proportion of Lasso Penalty (quantitative)
+## Range: [0, 1]
 ```
 
 ```r
 set.seed(283)
-cost_grid_1 <- grid_latin_hypercube(cost(), size = 1000)
-range(log2(cost_grid_1$cost))
+mix_grid_1 <- grid_latin_hypercube(mixture(), size = 1000)
+range(mix_grid_1$mixture)
 ```
 
 ```
-## [1] -9.998623 -1.000423
+## [1] 0.0001530482 0.9999530388
 ```
 
-However, in some cases, the `tune` package overrides the default ranges for specific models. If the grid function uses a `parameters` object created from a model or recipe, the ranges my have different defaults (specific to those models). Using the example above, the `cost` argument above is different for SVM models: 
-  
+However, in some cases, the `parsnip` and `recipe` packages overrides the default ranges for specific models and preprocessing steps. If the grid function uses a `parameters` object created from a model or recipe, the ranges may have different defaults (specific to those models). Using the example above, the `mixture` argument above is different for `glmnet` models: 
+
 
 ```r
 library(parsnip)
 library(tune)
 
-# When used in tune, the log2 range is [-10, 5]
-svm_mod <-
-  svm_rbf(cost = tune()) %>%
-  set_engine("kernlab")
+# When used with glmnet, the range is [0.05, 1.00]
+glmn_mod <-
+  linear_reg(mixture = tune()) %>%
+  set_engine("glmnet")
 
 set.seed(283)
-cost_grid_2 <- grid_latin_hypercube(parameters(svm_mod), size = 1000)
-range(log2(cost_grid_2$cost))
+mix_grid_2 <- grid_latin_hypercube(extract_parameter_set_dials(glmn_mod), size = 1000)
+range(mix_grid_2$mixture)
 ```
 
 ```
-## [1] -9.997704  4.999296
+## [1] 0.0501454 0.9999554
 ```


### PR DESCRIPTION
closes #210

In the example for space filling designs with an SVM model:
The defaults for `cost()` got changed in dials to the range that parsnip used: https://github.com/tidymodels/dials/commit/5031da8572829f9eb17b9e9be77b6cb4faa271c3
So the example didn't make much sense anymore. I've changed it to use `mixture()` in a glmnet model instead. 