### PR TITLE
update `parameters.default` prompt

### DIFF
--- a/R/parameters.R
+++ b/R/parameters.R
@@ -12,7 +12,10 @@ parameters <- function(x, ...) {
 #' @export
 #' @rdname parameters
 parameters.default <- function(x, ...) {
-  rlang::abort("`parameters` objects cannot be created from this type of object.")
+  rlang::abort(
+    glue("`parameters` objects cannot be created from objects ",
+         "of class `{class(x)[1]}`.")
+  )
 }
 
 #' @export

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -149,7 +149,7 @@
       value_set(cost_complexity(), log10(c(0.09, 1e-04)))
     Output
       Cost-Complexity Parameter (quantitative)
-      Transformer:  log-10 
+      Transformer: log-10 [1e-100, Inf]
       Range (transformed scale): [-10, -1]
       Values: 2
 

--- a/tests/testthat/_snaps/parameters.md
+++ b/tests/testthat/_snaps/parameters.md
@@ -47,3 +47,11 @@
       See `?dials::finalize` or `?dials::update.parameters` for more information.
       
 
+# parameters.default
+
+    Code
+      parameters(tibble::as_tibble(mtcars))
+    Condition
+      Error in `parameters()`:
+      ! `parameters` objects cannot be created from objects of class `tbl_df`.
+

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -48,6 +48,10 @@ test_that("printing", {
   expect_snapshot(parameters(list(mtry(), penalty())))
 })
 
+test_that("parameters.default", {
+  expect_snapshot(error = TRUE, parameters(tibble::as_tibble(mtcars)))
+})
+
 # ------------------------------------------------------------------------------
 # `[]`
 


### PR DESCRIPTION
``` r
library(dials)
#> Loading required package: scales

parameters(tibble::as_tibble(mtcars))
#> Error in `parameters()`:
#> ! `parameters` objects cannot be created from objects of class `tbl_df`.
```

<sup>Created on 2022-04-20 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Closes #225. :)