### PR TITLE
allow `values` to be supplied to `new_quant_param()` on its own without `range` and `inclusive`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # dials (development version)
 
+* `new_quant_param()` no longer requires `range` and `inclusive` if `values` is
+  supplied (#87).
+
+
 # dials 0.1.1
 
 * The `Chicago` data set was removed. It can be found in the `modeldata` package.

--- a/man/new-param.Rd
+++ b/man/new-param.Rd
@@ -8,8 +8,8 @@
 \usage{
 new_quant_param(
   type = c("double", "integer"),
-  range,
-  inclusive,
+  range = NULL,
+  inclusive = NULL,
   default = unknown(),
   trans = NULL,
   values = NULL,
@@ -33,10 +33,12 @@ choices are \code{"double"} and \code{"integer"} while for qualitative factors t
 \item{range}{A two-element vector with the smallest or largest possible
 values, respectively. If these cannot be set when the parameter is defined,
 the \code{unknown()} function can be used. If a transformation is specified,
-these values should be in the \emph{transformed units}.}
+these values should be in the \emph{transformed units}. If \code{values} is supplied,
+and \code{range} is \code{NULL}, \code{range} will be set to \code{range(values)}.}
 
 \item{inclusive}{A two-element logical vector for whether the range
-values should be inclusive or exclusive.}
+values should be inclusive or exclusive. If \code{values} is supplied,
+and \code{inclusive} is \code{NULL}, \code{inclusive} will be set to \code{c(TRUE, TRUE)}.}
 
 \item{default}{A single value with the same class as \code{type} for the default
 parameter value. \code{unknown()} can also be used here.}
@@ -47,7 +49,8 @@ transforms with \code{\link[scales:trans_new]{scales::trans_new()}}.}
 
 \item{values}{A vector of possible values that is required when \code{type} is
 \code{"character"} or \code{"logical"} but optional otherwise. For quantitative
-parameters, these override the \code{range} when generating sequences if set.}
+parameters, this can be used as an alternative to \code{range} and \code{inclusive}.
+If set, these will be used by \code{\link[=value_seq]{value_seq()}} and \code{\link[=value_sample]{value_sample()}}.}
 
 \item{label}{An optional named character string that can be used for
 printing and plotting. The name should match the object name (e.g.

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -209,3 +209,63 @@
       Error in `new_quant_param()`:
       ! An integer is required for the range and these do not appear to be whole numbers: 0.5
 
+# `values` must be compatible with `range` and `inclusive`
+
+    Code
+      new_quant_param(type = "integer", values = c(1L, 5L, 10L), range = c(1L, 5L),
+      label = c(foo = "Foo"))
+    Condition
+      Error in `new_quant_param()`:
+      ! Some values are not valid: 10
+
+---
+
+    Code
+      new_quant_param(type = "integer", values = c(1L, 5L, 10L), inclusive = c(TRUE,
+        FALSE), label = c(foo = "Foo"))
+    Condition
+      Error in `new_quant_param()`:
+      ! Some values are not valid: 10
+
+---
+
+    Code
+      new_quant_param(type = "integer", values = NULL, range = NULL, inclusive = c(
+        TRUE, FALSE), label = c(foo = "Foo"))
+    Condition
+      Error in `new_quant_param()`:
+      ! `range` must be supplied if `values` is `NULL`.
+
+---
+
+    Code
+      new_quant_param(type = "integer", values = NULL, range = c(1L, 10L), inclusive = NULL,
+      label = c(foo = "Foo"))
+    Condition
+      Error in `new_quant_param()`:
+      ! `inclusive` must be supplied if `values` is `NULL`.
+
+# `values` is validated
+
+    Code
+      new_quant_param(type = "integer", values = "not_numeric", label = c(foo = "Foo"))
+    Condition
+      Error in `new_quant_param()`:
+      ! `values` must be numeric.
+
+---
+
+    Code
+      new_quant_param(type = "integer", values = NA_integer_, label = c(foo = "Foo"))
+    Condition
+      Error in `new_quant_param()`:
+      ! `values` can't be `NA`.
+
+---
+
+    Code
+      new_quant_param(type = "integer", values = integer(), label = c(foo = "Foo"))
+    Condition
+      Error in `new_quant_param()`:
+      ! `values` can't be empty.
+

--- a/tests/testthat/test-constructors.R
+++ b/tests/testthat/test-constructors.R
@@ -111,3 +111,78 @@ test_that("bad ranges", {
   expect_snapshot(error = TRUE, mtry(c(.1, unknown())))
   expect_snapshot(error = TRUE, mtry(c(unknown(), .5)))
 })
+
+test_that("can supply `values` without `range` and `inclusive` (#87)", {
+  x <- new_quant_param(
+    type = "integer",
+    values = c(1L, 5L, 10L),
+    label = c(foo = "Foo")
+  )
+
+  expect_identical(x$range, list(lower = 1L, upper = 10L))
+  expect_identical(x$inclusive, c("lower" = TRUE, "upper" = TRUE))
+  expect_identical(x$values, c(1L, 5L, 10L))
+})
+
+test_that("`values` must be compatible with `range` and `inclusive`", {
+
+  expect_snapshot(error = TRUE, {
+    new_quant_param(
+      type = "integer",
+      values = c(1L, 5L, 10L),
+      range = c(1L, 5L),
+      label = c(foo = "Foo")
+    )
+  })
+  expect_snapshot(error = TRUE, {
+    new_quant_param(
+      type = "integer",
+      values = c(1L, 5L, 10L),
+      inclusive = c(TRUE, FALSE),
+      label = c(foo = "Foo")
+    )
+  })
+  expect_snapshot(error = TRUE, {
+    new_quant_param(
+      type = "integer",
+      values = NULL,
+      range = NULL,
+      inclusive = c(TRUE, FALSE),
+      label = c(foo = "Foo")
+    )
+  })
+  expect_snapshot(error = TRUE, {
+    new_quant_param(
+      type = "integer",
+      values = NULL,
+      range = c(1L, 10L),
+      inclusive = NULL,
+      label = c(foo = "Foo")
+    )
+  })
+
+})
+
+test_that("`values` is validated", {
+  expect_snapshot(error = TRUE, {
+    new_quant_param(
+      type = "integer",
+      values = "not_numeric",
+      label = c(foo = "Foo")
+    )
+  })
+  expect_snapshot(error = TRUE, {
+    new_quant_param(
+      type = "integer",
+      values = NA_integer_,
+      label = c(foo = "Foo")
+    )
+  })
+  expect_snapshot(error = TRUE, {
+    new_quant_param(
+      type = "integer",
+      values = integer(),
+      label = c(foo = "Foo")
+    )
+  })
+})


### PR DESCRIPTION
closes #87 

