### PR TITLE
workshop `print.parameters`

### DIFF
--- a/R/parameters.R
+++ b/R/parameters.R
@@ -168,7 +168,13 @@ print.parameters <- function(x, ...) {
   if (any(null_obj)) {
     needs_param <- print_x$identifier[null_obj]
 
-    param_descs <- combine_words(print_x$identifier[null_obj], before = "`")
+    last_sep <- if (length(needs_param) == 2) {"` and `"} else {"`, and `"}
+
+    param_descs <- paste0(
+      "`",
+      glue::glue_collapse(print_x$identifier[null_obj], sep = "`, `", last = last_sep),
+      "`"
+    )
 
     plural <- length(needs_param) != 1
 
@@ -296,52 +302,4 @@ identical_names <- function(x, y) {
   y_names <- names(y)
 
   identical(x_names, y_names)
-}
-
-# adapted from knitr::combine_words
-combine_words <- function(words, sep = ", ", and = " and ", before = "", after = before,
-          oxford_comma = TRUE)  {
-  n <- length(words)
-
-  rs <- function(x) {
-    if (is.null(x)) {
-      as.character(x)
-    } else {
-      x
-    }
-  }
-
-  if (n == 0) {
-    return(words)
-  }
-
-  words <- paste0(before, words, after)
-
-  if (n == 1) {
-    return(rs(words))
-  }
-
-  if (n == 2) {
-    return(rs(paste(words, collapse = if (is_blank(and)) sep else and)))
-  }
-
-  if (oxford_comma && grepl("^ ", and) && grepl(" $", sep))
-    and = gsub("^ ", "", and)
-
-  words[n] <- paste0(and, words[n])
-
-  if (!oxford_comma) {
-    words[n - 1] <- paste0(words[n - 1:0], collapse = "")
-    words <- words[-n]
-  }
-
-  rs(paste(words, collapse = sep))
-}
-
-is_blank <- function (x) {
-  if (length(x)) {
-    all(grepl("^\\s*$", x))
-  } else {
-    TRUE
-  }
 }

--- a/tests/testthat/_snaps/parameters.md
+++ b/tests/testthat/_snaps/parameters.md
@@ -47,6 +47,54 @@
       See `?dials::finalize` or `?dials::update.parameters` for more information.
       
 
+---
+
+    Code
+      boost_tree() %>% set_engine("C5.0", trials = tune()) %>%
+        extract_parameter_set_dials()
+    Output
+      Collection of 1 parameters for tuning
+      
+       identifier   type  object
+           trials trials missing
+      
+    Message
+      The parameter `trials` needs a `param` object. 
+      See `vignette('dials')` to learn more.
+
+---
+
+    Code
+      boost_tree() %>% set_engine("C5.0", trials = tune(), rules = tune()) %>%
+        extract_parameter_set_dials()
+    Output
+      Collection of 2 parameters for tuning
+      
+       identifier   type  object
+           trials trials missing
+            rules  rules missing
+      
+    Message
+      The parameters `trials` and `rules` need `param` objects. 
+      See `vignette('dials')` to learn more.
+
+---
+
+    Code
+      boost_tree() %>% set_engine("C5.0", trials = tune(), rules = tune(), costs = tune()) %>%
+        extract_parameter_set_dials()
+    Output
+      Collection of 3 parameters for tuning
+      
+       identifier   type  object
+           trials trials missing
+            rules  rules missing
+            costs  costs missing
+      
+    Message
+      The parameters `trials`, `rules`, and `costs` need `param` objects. 
+      See `vignette('dials')` to learn more.
+
 # parameters.default
 
     Code

--- a/tests/testthat/_snaps/parameters.md
+++ b/tests/testthat/_snaps/parameters.md
@@ -50,8 +50,7 @@
 ---
 
     Code
-      boost_tree() %>% set_engine("C5.0", trials = tune()) %>%
-        extract_parameter_set_dials()
+      ex_params[1, ] %>% structure(class = c("parameters", class(.)))
     Output
       Collection of 1 parameters for tuning
       
@@ -65,8 +64,7 @@
 ---
 
     Code
-      boost_tree() %>% set_engine("C5.0", trials = tune(), rules = tune()) %>%
-        extract_parameter_set_dials()
+      ex_params[1:2, ] %>% structure(class = c("parameters", class(.)))
     Output
       Collection of 2 parameters for tuning
       
@@ -81,8 +79,7 @@
 ---
 
     Code
-      boost_tree() %>% set_engine("C5.0", trials = tune(), rules = tune(), costs = tune()) %>%
-        extract_parameter_set_dials()
+      ex_params[1:3, ] %>% structure(class = c("parameters", class(.)))
     Output
       Collection of 3 parameters for tuning
       

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -46,6 +46,24 @@ test_that("updating", {
 
 test_that("printing", {
   expect_snapshot(parameters(list(mtry(), penalty())))
+
+  expect_snapshot(
+    boost_tree() %>%
+      set_engine("C5.0", trials = tune()) %>%
+      extract_parameter_set_dials()
+  )
+
+  expect_snapshot(
+    boost_tree() %>%
+      set_engine("C5.0", trials = tune(), rules = tune()) %>%
+      extract_parameter_set_dials()
+  )
+
+  expect_snapshot(
+    boost_tree() %>%
+      set_engine("C5.0", trials = tune(), rules = tune(), costs = tune()) %>%
+      extract_parameter_set_dials()
+  )
 })
 
 test_that("parameters.default", {

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -47,22 +47,23 @@ test_that("updating", {
 test_that("printing", {
   expect_snapshot(parameters(list(mtry(), penalty())))
 
-  expect_snapshot(
-    boost_tree() %>%
-      set_engine("C5.0", trials = tune()) %>%
-      extract_parameter_set_dials()
+  ex_params <- tibble::tribble(
+    ~name,    ~id,       ~source,      ~component,   ~call_info, ~component_id, ~object,
+    "trials", "trials",  "model_spec", "boost_tree", NULL,       "engine",      NA,
+    "rules",   "rules",  "model_spec", "boost_tree", NULL,       "engine",      NA,
+    "costs",   "costs",  "model_spec", "boost_tree", NULL,       "engine",      NA,
   )
 
   expect_snapshot(
-    boost_tree() %>%
-      set_engine("C5.0", trials = tune(), rules = tune()) %>%
-      extract_parameter_set_dials()
+    ex_params[1,] %>% structure(class = c("parameters", class(.)))
   )
 
   expect_snapshot(
-    boost_tree() %>%
-      set_engine("C5.0", trials = tune(), rules = tune(), costs = tune()) %>%
-      extract_parameter_set_dials()
+    ex_params[1:2,] %>% structure(class = c("parameters", class(.)))
+  )
+
+  expect_snapshot(
+    ex_params[1:3,] %>% structure(class = c("parameters", class(.)))
   )
 })
 


### PR DESCRIPTION
Closes \#230. 🦆

* Addresses tibble `Unknown or uninitialized column` message
* Points out which parameters need `param`s—visually (in the `tibble` output) + in the revised prompt
* Workshops the missing `params` prompt for pluralization
* Refers to where to find help (see reprex—users can see this message without having loaded the package + may be unfamiliar with what a `params` object is)
* Adds snapshot tests

Examples of old output:

``` r
# install.packages("dials")

library(parsnip)

boost_tree() %>%
  set_engine("C5.0", trials = tune()) %>%
  extract_parameter_set_dials()
#> Collection of 1 parameters for tuning
#> 
#>  identifier   type object
#>      trials trials    lgl
#> Warning: Unknown or uninitialised column: `identifier`.
#> One needs a `param` object: ''

boost_tree() %>%
  set_engine("C5.0", trials = tune(), rules = tune()) %>%
  extract_parameter_set_dials()
#> Collection of 2 parameters for tuning
#> 
#>  identifier   type object
#>      trials trials    lgl
#>       rules  rules    lgl
#> Warning: Unknown or uninitialised column: `identifier`.
#> Several need `param` objects:  ''

boost_tree() %>%
  set_engine("C5.0", trials = tune(), rules = tune(), costs = tune()) %>%
  extract_parameter_set_dials()
#> Collection of 3 parameters for tuning
#> 
#>  identifier   type object
#>      trials trials    lgl
#>       rules  rules    lgl
#>       costs  costs    lgl
#> Warning: Unknown or uninitialised column: `identifier`.
#> Several need `param` objects:  ''
```

Examples of new output:

``` r
# devtools::install_github("tidymodels/dials@prompting-230")

library(parsnip)

boost_tree() %>%
  set_engine("C5.0", trials = tune()) %>%
  extract_parameter_set_dials()
#> Collection of 1 parameters for tuning
#> 
#>  identifier   type  object
#>      trials trials missing
#> The parameter `trials` needs a `param` object. 
#> See `vignette('dials')` to learn more.

boost_tree() %>%
  set_engine("C5.0", trials = tune(), rules = tune()) %>%
  extract_parameter_set_dials()
#> Collection of 2 parameters for tuning
#> 
#>  identifier   type  object
#>      trials trials missing
#>       rules  rules missing
#> The parameters `trials` and `rules` need `param` objects. 
#> See `vignette('dials')` to learn more.

boost_tree() %>%
  set_engine("C5.0", trials = tune(), rules = tune(), costs = tune()) %>%
  extract_parameter_set_dials()
#> Collection of 3 parameters for tuning
#> 
#>  identifier   type  object
#>      trials trials missing
#>       rules  rules missing
#>       costs  costs missing
#> The parameters `trials`, `rules`, and `costs` need `param` objects. 
#> See `vignette('dials')` to learn more.
```

Will self-review to point out a couple of things I’d appreciate an eye for.

<sup>Created on 2022-04-24 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>