### PR TITLE
allow `label` to be NULL

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -52,10 +52,7 @@ check_installs <- function(x) {
 check_label <- function(txt, ..., call = caller_env()) {
   check_dots_empty()
   if (is.null(txt)) {
-    rlang::abort(
-      "`label` should be a single named character string or NULL.",
-      call = call
-    )
+    return(invisible(txt))
   }
   if (!is.character(txt) || length(txt) > 1) {
     rlang::abort(

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -27,16 +27,16 @@
     Code
       new_quant_param("double", range = 1, inclusive = c(TRUE, TRUE))
     Condition
-      Error in `new_quant_param()`:
-      ! `label` should be a single named character string or NULL.
+      Error in `names(range) <- names(inclusive) <- c("lower", "upper")`:
+      ! 'names' attribute [2] must be the same length as the vector [1]
 
 ---
 
     Code
       new_quant_param("double", range = c(1, NA), inclusive = c(TRUE, TRUE))
     Condition
-      Error in `new_quant_param()`:
-      ! `label` should be a single named character string or NULL.
+      Error in `range_validate()`:
+      ! Value ranges must be non-missing.
 
 ---
 
@@ -59,8 +59,8 @@
     Code
       new_quant_param("double", range = c(1, NA), inclusive = c(TRUE, TRUE))
     Condition
-      Error in `new_quant_param()`:
-      ! `label` should be a single named character string or NULL.
+      Error in `range_validate()`:
+      ! Value ranges must be non-missing.
 
 ---
 

--- a/tests/testthat/_snaps/misc.md
+++ b/tests/testthat/_snaps/misc.md
@@ -6,3 +6,19 @@
       Error in `dials:::check_installs()`:
       ! Package(s) not installed: 'pistachio'
 
+# check_label()
+
+    Code
+      check_label("unnamed label")
+    Condition
+      Error:
+      ! `label` should be a single named character string or NULL.
+
+---
+
+    Code
+      check_label(c("more", "than", "one", "label"))
+    Condition
+      Error:
+      ! `label` should be a single named character string or NULL.
+

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -38,3 +38,11 @@ test_that("formatting", {
     "?"
   )
 })
+
+test_that("check_label()", {
+  expect_no_error(check_label(NULL))
+  expect_no_error(check_label(c("label_name" = "label")))
+
+  expect_snapshot(error = TRUE, check_label("unnamed label"))
+  expect_snapshot(error = TRUE, check_label(c("more", "than", "one", "label")))
+})


### PR DESCRIPTION
closes #266

``` r
library(dials)
#> Loading required package: scales

new_quant_param(type = "double", range = c(0, 1), inclusive = c(TRUE, TRUE),
                label = NULL)
#> Quantitative Parameter
#> Range: [0, 1]
```

<sup>Created on 2022-11-23 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>