### PR TITLE
Checking inputs for constructor

### DIFF
--- a/R/constructors.R
+++ b/R/constructors.R
@@ -120,15 +120,7 @@ new_quant_param <- function(type = c("double", "integer"),
     range <- as.list(range)
   }
 
-  if (length(inclusive) != 2) {
-    rlang::abort("`inclusive` must have upper and lower values.")
-  }
-  if (any(is.na(inclusive))) {
-    rlang::abort("Boundary descriptors must be non-missing.")
-  }
-  if (!is.logical(inclusive)) {
-    rlang::abort("`inclusive` should be logical")
-  }
+  check_inclusive(inclusive)
 
   if (!is.null(trans)) {
     if (!is.trans(trans)) {

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -93,17 +93,9 @@ new_quant_param <- function(type = c("double", "integer"),
     rlang::abort("`type` should be either 'double' or 'integer'.")
   }
 
-  if (!is.null(values)) {
-    if (!is.numeric(values)) {
-      rlang::abort("`values` must be numeric.")
-    }
-    if (anyNA(values)) {
-      rlang::abort("`values` can't be `NA`.")
-    }
-    if (length(values) == 0) {
-      rlang::abort("`values` can't be empty.")
-    }
+  check_values_quant(values)
 
+  if (!is.null(values)) {
     # fill in range if user didn't supply one
     if (is.null(range)) {
       range <- range(values)

--- a/R/misc.R
+++ b/R/misc.R
@@ -136,3 +136,17 @@ check_values_quant <- function(x, ..., call = caller_env()) {
   invisible(x)
 }
 
+check_inclusive <- function(x, ..., call = caller_env()) {
+  check_dots_empty()
+  if (length(x) != 2) {
+    rlang::abort("`inclusive` must have upper and lower values.", call = call)
+  }
+  if (any(is.na(x))) {
+    rlang::abort("`inclusive` must be non-missing.", call = call)
+  }
+  if (!is.logical(x)) {
+    rlang::abort("`inclusive` should be logical", call = call)
+  }
+  invisible(x)
+}
+

--- a/R/misc.R
+++ b/R/misc.R
@@ -115,3 +115,24 @@ check_range <- function(x, type, trans, ..., call = caller_env()) {
   }
   invisible(x0)
 }
+
+check_values_quant <- function(x, ..., call = caller_env()) {
+  check_dots_empty()
+
+  if (is.null(x)) {
+    return(invisible(x))
+  }
+
+  if (!is.numeric(x)) {
+    rlang::abort("`values` must be numeric.", call = call)
+  }
+  if (anyNA(x)) {
+    rlang::abort("`values` can't be `NA`.", call = call)
+  }
+  if (length(x) == 0) {
+    rlang::abort("`values` can't be empty.", call = call)
+  }
+
+  invisible(x)
+}
+

--- a/tests/testthat/_snaps/misc.md
+++ b/tests/testthat/_snaps/misc.md
@@ -22,6 +22,14 @@
       Error:
       ! `label` should be a single named character string or NULL.
 
+# check_finalize()
+
+    Code
+      check_finalize("not a function or NULL")
+    Condition
+      Error:
+      ! `finalize` should be NULL or a function.
+
 # check_values_quant()
 
     Code

--- a/tests/testthat/_snaps/misc.md
+++ b/tests/testthat/_snaps/misc.md
@@ -22,3 +22,27 @@
       Error:
       ! `label` should be a single named character string or NULL.
 
+# check_values_quant()
+
+    Code
+      check_values_quant("should have been a numeric")
+    Condition
+      Error:
+      ! `values` must be numeric.
+
+---
+
+    Code
+      check_values_quant(c(1, NA))
+    Condition
+      Error:
+      ! `values` can't be `NA`.
+
+---
+
+    Code
+      check_values_quant(numeric())
+    Condition
+      Error:
+      ! `values` can't be empty.
+

--- a/tests/testthat/_snaps/misc.md
+++ b/tests/testthat/_snaps/misc.md
@@ -46,3 +46,35 @@
       Error:
       ! `values` can't be empty.
 
+# check_inclusive()
+
+    Code
+      check_inclusive(TRUE)
+    Condition
+      Error:
+      ! `inclusive` must have upper and lower values.
+
+---
+
+    Code
+      check_inclusive(NULL)
+    Condition
+      Error:
+      ! `inclusive` must have upper and lower values.
+
+---
+
+    Code
+      check_inclusive(c(TRUE, NA))
+    Condition
+      Error:
+      ! `inclusive` must be non-missing.
+
+---
+
+    Code
+      check_inclusive(1:2)
+    Condition
+      Error:
+      ! `inclusive` should be logical
+

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -47,6 +47,14 @@ test_that("check_label()", {
   expect_snapshot(error = TRUE, check_label(c("more", "than", "one", "label")))
 })
 
+test_that("check_finalize()", {
+  expect_no_error(check_finalize(NULL))
+  a_function <- mean
+  expect_no_error(check_finalize(a_function))
+
+  expect_snapshot(error = TRUE, check_finalize("not a function or NULL"))
+})
+
 test_that("check_values_quant()", {
   expect_no_error(check_values_quant(NULL))
   expect_snapshot(error = TRUE, check_values_quant("should have been a numeric"))

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -46,3 +46,10 @@ test_that("check_label()", {
   expect_snapshot(error = TRUE, check_label("unnamed label"))
   expect_snapshot(error = TRUE, check_label(c("more", "than", "one", "label")))
 })
+
+test_that("check_values_quant()", {
+  expect_no_error(check_values_quant(NULL))
+  expect_snapshot(error = TRUE, check_values_quant("should have been a numeric"))
+  expect_snapshot(error = TRUE, check_values_quant(c(1, NA)))
+  expect_snapshot(error = TRUE, check_values_quant(numeric()))
+})

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -53,3 +53,11 @@ test_that("check_values_quant()", {
   expect_snapshot(error = TRUE, check_values_quant(c(1, NA)))
   expect_snapshot(error = TRUE, check_values_quant(numeric()))
 })
+
+test_that("check_inclusive()", {
+  expect_no_error(check_inclusive(c(TRUE, TRUE)))
+  expect_snapshot(error = TRUE, check_inclusive(TRUE))
+  expect_snapshot(error = TRUE, check_inclusive(NULL))
+  expect_snapshot(error = TRUE, check_inclusive(c(TRUE, NA)))
+  expect_snapshot(error = TRUE, check_inclusive(1:2))
+})


### PR DESCRIPTION
This PR pulls out more of the input checking for the (quant) constructor into separate helper functions so that we can test those individually.