### PR TITLE
Pass `call` down the parameter constructor to the error 

### DIFF
--- a/R/aaa_ranges.R
+++ b/R/aaa_ranges.R
@@ -13,6 +13,8 @@
 #' @param original A single logical. Should the range values be in the natural
 #'  units (`TRUE`) or in the transformed space (`FALSE`, if applicable)?
 #'
+#' @inheritParams new-param
+#'
 #' @return
 #'
 #' `range_validate()` returns the new range if it passes the validation
@@ -42,7 +44,12 @@
 #'   range_get()
 #'
 #' @export
-range_validate <- function(object, range, ukn_ok = TRUE) {
+range_validate <- function(object,
+                           range,
+                           ukn_ok = TRUE,
+                           ...,
+                           call = caller_env()
+                           ) {
   ukn_txt <- if (ukn_ok) {
     "`Inf` and `unknown()` are acceptable values."
   } else {
@@ -50,7 +57,8 @@ range_validate <- function(object, range, ukn_ok = TRUE) {
   }
   if (length(range) != 2) {
     rlang::abort(
-      paste("`range` must have two values: an upper and lower bound.", ukn_txt)
+      paste("`range` must have two values: an upper and lower bound.", ukn_txt),
+      call = call
     )
   }
 
@@ -60,19 +68,22 @@ range_validate <- function(object, range, ukn_ok = TRUE) {
 
   if (!ukn_ok) {
     if (any(is_unk)) {
-      rlang::abort("Cannot validate ranges when they contains 1+ unknown values.")
+      rlang::abort(
+        "Cannot validate ranges when they contains 1+ unknown values.",
+        call = call
+      )
     }
     if (!any(is_num)) {
-      rlang::abort("`range` should be numeric.")
+      rlang::abort("`range` should be numeric.", call = call)
     }
 
     # TODO check with transform
   } else {
     if (any(is_na[!is_unk])) {
-      rlang::abort("Value ranges must be non-missing.", ukn_txt)
+      rlang::abort("Value ranges must be non-missing.", ukn_txt, call = call)
     }
     if (any(!is_num[!is_unk])) {
-      rlang::abort("Value ranges must be numeric.", ukn_txt)
+      rlang::abort("Value ranges must be numeric.", ukn_txt, call = call)
     }
   }
   range

--- a/R/aaa_values.R
+++ b/R/aaa_values.R
@@ -17,6 +17,8 @@
 #' @param original A single logical. Should the range values be in the natural
 #'  units (`TRUE`) or in the transformed space (`FALSE`, if applicable)?
 #'
+#' @inheritParams new-param
+#'
 #' @return
 #'
 #' `value_validate()` throws an error or silently returns `values` if they are
@@ -70,12 +72,12 @@
 #' cost_complexity() %>% value_sample(2)
 #'
 #' @export
-value_validate <- function(object, values) {
+value_validate <- function(object, values, ..., call = caller_env()) {
   res <- switch(object$type,
     double = ,
-    integer = value_validate_quant(object, values),
+    integer = value_validate_quant(object, values, call = call),
     character = ,
-    logical = value_validate_qual(object, values)
+    logical = value_validate_qual(object, values, call = call)
   )
   unlist(res)
 }

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -157,7 +157,7 @@ new_quant_param <- function(type = c("double", "integer"),
   range_validate(res, range, call = call)
 
   if (!is.null(values)) {
-    ok_vals <- value_validate(res, values)
+    ok_vals <- value_validate(res, values, call = call)
     if (all(ok_vals)) {
       res$values <- values
     } else {

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -121,7 +121,7 @@ new_quant_param <- function(type = c("double", "integer"),
     )
   }
 
-  range <- check_range(range, type, trans)
+  range <- check_range(range, type, trans, call = call)
 
   if (!is.list(range)) {
     range <- as.list(range)

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -183,7 +183,9 @@ new_qual_param <- function(type = c("character", "logical"),
                            values,
                            default = deprecated(),
                            label = NULL,
-                           finalize = NULL) {
+                           finalize = NULL,
+                           ...,
+                           call = caller_env()) {
   if (lifecycle::is_present(default)) {
     lifecycle::deprecate_warn(when = "1.0.1", what = "new_qual_param(default)")
   }
@@ -192,17 +194,17 @@ new_qual_param <- function(type = c("character", "logical"),
 
   if (type == "logical") {
     if (!is.logical(values)) {
-      rlang::abort("`values` must be logical")
+      rlang::abort("`values` must be logical", call = call)
     }
   }
   if (type == "character") {
     if (!is.character(values)) {
-      rlang::abort("`values` must be character")
+      rlang::abort("`values` must be character", call = call)
     }
   }
 
-  check_label(label)
-  check_function(finalize, allow_null = TRUE)
+  check_label(label, call = call)
+  check_function(finalize, allow_null = TRUE, call = call)
 
   res <- list(
     type = type,

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -192,17 +192,11 @@ new_qual_param <- function(type = c("character", "logical"),
 
   type <- arg_match0(type, values = c("character", "logical"))
 
-  if (type == "logical") {
-    if (!is.logical(values)) {
-      rlang::abort("`values` must be logical", call = call)
-    }
-  }
-  if (type == "character") {
-    if (!is.character(values)) {
-      rlang::abort("`values` must be character", call = call)
-    }
-  }
-
+  switch(
+    type,
+    "logical" = check_logical(values, call = call),
+    "character" = check_character(values, call = call)
+  )
   check_label(label, call = call)
   check_function(finalize, allow_null = TRUE, call = call)
 

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -154,7 +154,7 @@ new_quant_param <- function(type = c("double", "integer"),
     finalize = finalize
   )
   class(res) <- c("quant_param", "param")
-  range_validate(res, range)
+  range_validate(res, range, call = call)
 
   if (!is.null(values)) {
     ok_vals <- value_validate(res, values)

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -87,11 +87,7 @@ new_quant_param <- function(type = c("double", "integer"),
     )
   }
 
-  type <- match.arg(type)
-
-  if (!(type %in% c("double", "integer"))) {
-    rlang::abort("`type` should be either 'double' or 'integer'.")
-  }
+  type <- arg_match0(type, values = c("double", "integer"))
 
   check_values_quant(values)
 
@@ -181,7 +177,7 @@ new_qual_param <- function(type = c("character", "logical"),
     lifecycle::deprecate_warn(when = "1.0.1", what = "new_qual_param(default)")
   }
 
-  type <- match.arg(type)
+  type <- arg_match0(type, values = c("character", "logical"))
 
   if (type == "logical") {
     if (!is.logical(values)) {

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -97,7 +97,7 @@ new_quant_param <- function(type = c("double", "integer"),
 
   type <- arg_match0(type, values = c("double", "integer"))
 
-  check_values_quant(values)
+  check_values_quant(values, call = call)
 
   if (!is.null(values)) {
     # fill in range if user didn't supply one

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -141,8 +141,8 @@ new_quant_param <- function(type = c("double", "integer"),
     }
   }
 
-  check_label(label)
-  check_function(finalize, allow_null = TRUE)
+  check_label(label, call = call)
+  check_function(finalize, allow_null = TRUE, call = call)
 
   names(range) <- names(inclusive) <- c("lower", "upper")
   res <- list(

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -161,17 +161,16 @@ new_quant_param <- function(type = c("double", "integer"),
     if (all(ok_vals)) {
       res$values <- values
     } else {
-      rlang::abort(
-        paste0(
-          "Some values are not valid: ",
-          glue_collapse(
-            values[!ok_vals],
-            sep = ", ",
-            last = " and ",
-            width = min(options()$width - 30, 10)
-          )
+      msg <- paste0(
+        "Some values are not valid: ",
+        glue_collapse(
+          values[!ok_vals],
+          sep = ", ",
+          last = " and ",
+          width = min(options()$width - 30, 10)
         )
       )
+      rlang::abort(msg, call = call)
     }
   }
 

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -112,10 +112,13 @@ new_quant_param <- function(type = c("double", "integer"),
   }
 
   if (is.null(range)) {
-    rlang::abort("`range` must be supplied if `values` is `NULL`.")
+    rlang::abort("`range` must be supplied if `values` is `NULL`.", call = call)
   }
   if (is.null(inclusive)) {
-    rlang::abort("`inclusive` must be supplied if `values` is `NULL`.")
+    rlang::abort(
+      "`inclusive` must be supplied if `values` is `NULL`.",
+      call = call
+    )
   }
 
   range <- check_range(range, type, trans)

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -38,6 +38,10 @@
 #' @param finalize A function that can be used to set the data-specific
 #' values of a parameter (such as the `range`).
 #'
+#' @inheritParams rlang::args_dots_empty
+#'
+#' @param call The call passed on to [rlang::abort()].
+#'
 #' @return
 #'
 #' An object of class `"param"` with the primary class being either
@@ -79,13 +83,17 @@ new_quant_param <- function(type = c("double", "integer"),
                             trans = NULL,
                             values = NULL,
                             label = NULL,
-                            finalize = NULL) {
+                            finalize = NULL,
+                            ...,
+                            call = caller_env()) {
   if (lifecycle::is_present(default)) {
     lifecycle::deprecate_warn(
       when = "1.0.1",
       what = "new_quant_param(default)"
     )
   }
+
+  check_dots_empty()
 
   type <- arg_match0(type, values = c("double", "integer"))
 

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -132,10 +132,11 @@ new_quant_param <- function(type = c("double", "integer"),
   if (!is.null(trans)) {
     if (!is.trans(trans)) {
       rlang::abort(
-        paste0(
-          "`trans` must be a 'trans' class object (or NULL). See ",
-          "`?scales::trans_new`."
-        )
+        c(
+          "`trans` must be a 'trans' class object (or `NULL`).",
+          i = "See `?scales::trans_new`."
+        ),
+        call = call
       )
     }
   }

--- a/man/new-param.Rd
+++ b/man/new-param.Rd
@@ -24,7 +24,9 @@ new_qual_param(
   values,
   default = deprecated(),
   label = NULL,
-  finalize = NULL
+  finalize = NULL,
+  ...,
+  call = caller_env()
 )
 }
 \arguments{

--- a/man/new-param.Rd
+++ b/man/new-param.Rd
@@ -14,7 +14,9 @@ new_quant_param(
   trans = NULL,
   values = NULL,
   label = NULL,
-  finalize = NULL
+  finalize = NULL,
+  ...,
+  call = caller_env()
 )
 
 new_qual_param(
@@ -59,6 +61,10 @@ printing and plotting. The name should match the object name (e.g.
 
 \item{finalize}{A function that can be used to set the data-specific
 values of a parameter (such as the \code{range}).}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{call}{The call passed on to \code{\link[rlang:abort]{rlang::abort()}}.}
 }
 \value{
 An object of class \code{"param"} with the primary class being either

--- a/man/range_validate.Rd
+++ b/man/range_validate.Rd
@@ -6,7 +6,7 @@
 \alias{range_set}
 \title{Tools for working with parameter ranges}
 \usage{
-range_validate(object, range, ukn_ok = TRUE)
+range_validate(object, range, ukn_ok = TRUE, ..., call = caller_env())
 
 range_get(object, original = TRUE)
 
@@ -20,6 +20,10 @@ can include \code{unknown()} when \code{ukn_ok = TRUE}.}
 
 \item{ukn_ok}{A single logical for whether \code{unknown()} is
 an acceptable value.}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{call}{The call passed on to \code{\link[rlang:abort]{rlang::abort()}}.}
 
 \item{original}{A single logical. Should the range values be in the natural
 units (\code{TRUE}) or in the transformed space (\code{FALSE}, if applicable)?}

--- a/man/value_validate.Rd
+++ b/man/value_validate.Rd
@@ -9,7 +9,7 @@
 \alias{value_set}
 \title{Tools for working with parameter values}
 \usage{
-value_validate(object, values)
+value_validate(object, values, ..., call = caller_env())
 
 value_seq(object, n, original = TRUE)
 
@@ -27,6 +27,10 @@ value_set(object, values)
 \item{values}{A numeric vector or list (including \code{Inf}). Values
 \emph{cannot} include \code{unknown()}. For \code{value_validate()}, the units should be
 consistent with the parameter object's definition.}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{call}{The call passed on to \code{\link[rlang:abort]{rlang::abort()}}.}
 
 \item{n}{An integer for the (maximum) number of values to return. In some
 cases where a sequence is requested, the result might have less than \code{n}

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -19,8 +19,8 @@
     Code
       new_quant_param("mucus", range = 1:2, inclusive = c(TRUE, TRUE))
     Condition
-      Error in `match.arg()`:
-      ! 'arg' should be one of "double", "integer"
+      Error in `new_quant_param()`:
+      ! `type` must be one of "double" or "integer", not "mucus".
 
 ---
 

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -35,7 +35,7 @@
     Code
       new_quant_param("double", range = c(1, NA), inclusive = c(TRUE, TRUE))
     Condition
-      Error in `range_validate()`:
+      Error in `new_quant_param()`:
       ! Value ranges must be non-missing.
 
 ---
@@ -59,7 +59,7 @@
     Code
       new_quant_param("double", range = c(1, NA), inclusive = c(TRUE, TRUE))
     Condition
-      Error in `range_validate()`:
+      Error in `new_quant_param()`:
       ! Value ranges must be non-missing.
 
 ---
@@ -108,7 +108,7 @@
     Code
       range_validate(mtry(), range = 1)
     Condition
-      Error in `range_validate()`:
+      Error:
       ! `range` must have two values: an upper and lower bound. `Inf` and `unknown()` are acceptable values.
 
 ---
@@ -116,7 +116,7 @@
     Code
       range_validate(mtry(), range = c(1, NA))
     Condition
-      Error in `range_validate()`:
+      Error:
       ! Value ranges must be non-missing.
 
 ---
@@ -124,7 +124,7 @@
     Code
       range_validate(mtry(), range = c(1, unknown()), FALSE)
     Condition
-      Error in `range_validate()`:
+      Error:
       ! Cannot validate ranges when they contains 1+ unknown values.
 
 ---
@@ -132,7 +132,7 @@
     Code
       range_validate(mtry(), range = letters[1:2])
     Condition
-      Error in `range_validate()`:
+      Error:
       ! Value ranges must be numeric.
 
 # printing

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -92,7 +92,7 @@
     Code
       new_quant_param("integer", range = 1:2, inclusive = c(TRUE, TRUE), values = 1:4)
     Condition
-      Error in `new_quant_param()`:
+      Error:
       ! Some values are not valid: 3 and 4
 
 ---
@@ -226,7 +226,7 @@
       new_quant_param(type = "integer", values = c(1L, 5L, 10L), range = c(1L, 5L),
       label = c(foo = "Foo"))
     Condition
-      Error in `new_quant_param()`:
+      Error:
       ! Some values are not valid: 10
 
 ---
@@ -235,7 +235,7 @@
       new_quant_param(type = "integer", values = c(1L, 5L, 10L), inclusive = c(TRUE,
         FALSE), label = c(foo = "Foo"))
     Condition
-      Error in `new_quant_param()`:
+      Error:
       ! Some values are not valid: 10
 
 ---

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -100,7 +100,7 @@
     Code
       new_quant_param("integer", range = 1:2, inclusive = c(TRUE, TRUE), finalize = "not a function or NULL")
     Condition
-      Error in `new_quant_param()`:
+      Error:
       ! `finalize` must be a function or `NULL`, not the string "not a function or NULL".
 
 # bad args to range_validate

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -4,7 +4,7 @@
       new_qual_param("character", 1:2)
     Condition
       Error:
-      ! `values` must be character
+      ! `values` must be a character vector, not an integer vector.
 
 ---
 
@@ -12,7 +12,7 @@
       new_qual_param("logical", letters[1:2])
     Condition
       Error:
-      ! `values` must be logical
+      ! `values` must be a logical vector, not a character vector.
 
 # quantitative parameter object creation - bad args
 

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -243,7 +243,7 @@
       new_quant_param(type = "integer", values = NULL, range = NULL, inclusive = c(
         TRUE, FALSE), label = c(foo = "Foo"))
     Condition
-      Error in `new_quant_param()`:
+      Error:
       ! `range` must be supplied if `values` is `NULL`.
 
 ---
@@ -252,7 +252,7 @@
       new_quant_param(type = "integer", values = NULL, range = c(1L, 10L), inclusive = NULL,
       label = c(foo = "Foo"))
     Condition
-      Error in `new_quant_param()`:
+      Error:
       ! `inclusive` must be supplied if `values` is `NULL`.
 
 # `values` is validated

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -3,7 +3,7 @@
     Code
       new_qual_param("character", 1:2)
     Condition
-      Error in `new_qual_param()`:
+      Error:
       ! `values` must be character
 
 ---
@@ -11,7 +11,7 @@
     Code
       new_qual_param("logical", letters[1:2])
     Condition
-      Error in `new_qual_param()`:
+      Error:
       ! `values` must be logical
 
 # quantitative parameter object creation - bad args

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -35,7 +35,7 @@
     Code
       new_quant_param("double", range = c(1, NA), inclusive = c(TRUE, TRUE))
     Condition
-      Error in `new_quant_param()`:
+      Error:
       ! Value ranges must be non-missing.
 
 ---
@@ -59,7 +59,7 @@
     Code
       new_quant_param("double", range = c(1, NA), inclusive = c(TRUE, TRUE))
     Condition
-      Error in `new_quant_param()`:
+      Error:
       ! Value ranges must be non-missing.
 
 ---

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -83,8 +83,9 @@
     Code
       new_quant_param("integer", range = 1:2, inclusive = c(TRUE, TRUE), trans = log)
     Condition
-      Error in `new_quant_param()`:
-      ! `trans` must be a 'trans' class object (or NULL). See `?scales::trans_new`.
+      Error:
+      ! `trans` must be a 'trans' class object (or `NULL`).
+      i See `?scales::trans_new`.
 
 ---
 

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -260,7 +260,7 @@
     Code
       new_quant_param(type = "integer", values = "not_numeric", label = c(foo = "Foo"))
     Condition
-      Error in `new_quant_param()`:
+      Error:
       ! `values` must be numeric.
 
 ---
@@ -268,7 +268,7 @@
     Code
       new_quant_param(type = "integer", values = NA_integer_, label = c(foo = "Foo"))
     Condition
-      Error in `new_quant_param()`:
+      Error:
       ! `values` can't be `NA`.
 
 ---
@@ -276,7 +276,7 @@
     Code
       new_quant_param(type = "integer", values = integer(), label = c(foo = "Foo"))
     Condition
-      Error in `new_quant_param()`:
+      Error:
       ! `values` can't be empty.
 
 # `default` arg is deprecated

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -168,7 +168,7 @@
     Code
       mixture(c(1L, 3L))
     Condition
-      Error in `new_quant_param()`:
+      Error in `mixture()`:
       ! Since `type = 'double'`, please use that data type for the range.
 
 ---
@@ -176,7 +176,7 @@
     Code
       mixture(c(1L, unknown()))
     Condition
-      Error in `new_quant_param()`:
+      Error in `mixture()`:
       ! Since `type = 'double'`, please use that data type for the range.
 
 ---
@@ -184,7 +184,7 @@
     Code
       mixture(c(unknown(), 1L))
     Condition
-      Error in `new_quant_param()`:
+      Error in `mixture()`:
       ! Since `type = 'double'`, please use that data type for the range.
 
 ---
@@ -192,7 +192,7 @@
     Code
       mixture(letters[1:2])
     Condition
-      Error in `new_quant_param()`:
+      Error in `mixture()`:
       ! Since `type = 'double'`, please use that data type for the range.
 
 ---
@@ -200,7 +200,7 @@
     Code
       mtry(c(0.1, 0.5))
     Condition
-      Error in `new_quant_param()`:
+      Error in `mtry()`:
       ! An integer is required for the range and these do not appear to be whole numbers: 0.1, 0.5
 
 ---
@@ -208,7 +208,7 @@
     Code
       mtry(c(0.1, unknown()))
     Condition
-      Error in `new_quant_param()`:
+      Error in `mtry()`:
       ! An integer is required for the range and these do not appear to be whole numbers: 0.1
 
 ---
@@ -216,7 +216,7 @@
     Code
       mtry(c(unknown(), 0.5))
     Condition
-      Error in `new_quant_param()`:
+      Error in `mtry()`:
       ! An integer is required for the range and these do not appear to be whole numbers: 0.5
 
 # `values` must be compatible with `range` and `inclusive`

--- a/tests/testthat/_snaps/values.md
+++ b/tests/testthat/_snaps/values.md
@@ -52,6 +52,6 @@
     Code
       value_validate(mtry(), 17)
     Condition
-      Error in `value_validate()`:
+      Error:
       ! Unknowns not allowed.
 


### PR DESCRIPTION
This PR enables passing the call down to the `abort()` calls of the various checks in the two constructors `new_quant_param()` and `new_qual_param()`. 

This means that passing an incorrect `range` to one of the parameter functions will lead to that call being shown, rather than the constructor, and so addresses the first part of #271

``` r
library(dials)
#> Loading required package: scales

degree(1L)
#> Error in `degree()`:
#> ! Since `type = 'double'`, please use that data type for the range.
```

<sup>Created on 2023-03-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>