### PR TITLE
Update errors from `encode_unit()`

### DIFF
--- a/R/encode_unit.R
+++ b/R/encode_unit.R
@@ -82,8 +82,7 @@ encode_unit.qual_param <- function(x, value, direction, ...) {
       bad_vals <- compl[!(compl %in% ref_vals)]
       rlang::abort(
         "Some values are not in the reference set of possible values: ",
-        paste0("'", unique(bad_vals), "'", collapse = ", "),
-        call. = FALSE
+        paste0("'", unique(bad_vals), "'", collapse = ", ")
       )
     }
     fac <- factor(value, levels = ref_vals)

--- a/R/encode_unit.R
+++ b/R/encode_unit.R
@@ -20,17 +20,17 @@ encode_unit <- function(x, value, direction, ...) {
 
 #' @export
 encode_unit.default <- function(x, value, direction, ...) {
-  rlang::abort("`x` should be a dials parameter object.", .internal = TRUE)
+  rlang::abort("`x` should be a dials parameter object.")
 }
 
 #' @export
 encode_unit.quant_param <- function(x, value, direction, original = TRUE, ...) {
   if (has_unknowns(x)) {
-    rlang::abort("The parameter object contains unknowns.", .internal = TRUE)
+    rlang::abort("The parameter object contains unknowns.")
   }
 
   if (!is.numeric(value) || is.matrix(value)) {
-    rlang::abort("`value` should be a numeric vector.", .internal = TRUE)
+    rlang::abort("`value` should be a numeric vector.")
   }
 
   param_rng <- x$range$upper - x$range$lower
@@ -42,7 +42,7 @@ encode_unit.quant_param <- function(x, value, direction, original = TRUE, ...) {
 
     compl <- value[!is.na(value)]
     if (any(compl < 0) | any(compl > 1)) {
-      rlang::abort("Values should be on [0, 1].", .internal = TRUE)
+      rlang::abort("Values should be on [0, 1].")
     }
 
     value <- (value * param_rng) + x$range$lower
@@ -64,7 +64,7 @@ encode_unit.quant_param <- function(x, value, direction, original = TRUE, ...) {
 #' @export
 encode_unit.qual_param <- function(x, value, direction, ...) {
   if (has_unknowns(x)) {
-    rlang::abort("The parameter object contains unknowns.", .internal = TRUE)
+    rlang::abort("The parameter object contains unknowns.")
   }
 
   ref_vals <- x$values
@@ -74,7 +74,7 @@ encode_unit.qual_param <- function(x, value, direction, ...) {
     # convert to [0, 1]
 
     if (!is.character(value) || is.matrix(value)) {
-      rlang::abort("`value` should be a character vector.", .internal = TRUE)
+      rlang::abort("`value` should be a character vector.")
     }
 
     compl <- value[!is.na(value)]
@@ -93,11 +93,11 @@ encode_unit.qual_param <- function(x, value, direction, ...) {
 
     compl <- value[!is.na(value)]
     if (any(compl < 0) | any(compl > 1)) {
-      rlang::abort("Values should be on [0, 1].", .internal = TRUE)
+      rlang::abort("Values should be on [0, 1].")
     }
 
     if (!is.numeric(value) || is.matrix(value)) {
-      rlang::abort("`value` should be a numeric vector.", .internal = TRUE)
+      rlang::abort("`value` should be a numeric vector.")
     }
 
     ind <- cut(value, breaks = seq(0, 1, length.out = num_lvl + 1), include.lowest = TRUE)

--- a/R/encode_unit.R
+++ b/R/encode_unit.R
@@ -14,12 +14,7 @@
 #' @keywords internal
 #' @export
 encode_unit <- function(x, value, direction, ...) {
-  if (!any(direction %in% c("forward", "backward"))) {
-    rlang::abort(
-      "`direction` should be either 'forward' or 'backward'",
-      .internal = TRUE
-    )
-  }
+  arg_match0(direction, values = c("forward", "backward"))
   UseMethod("encode_unit")
 }
 

--- a/tests/testthat/_snaps/encode_unit.md
+++ b/tests/testthat/_snaps/encode_unit.md
@@ -5,8 +5,6 @@
     Condition
       Error in `encode_unit()`:
       ! `x` should be a dials parameter object.
-      i This is an internal error that was detected in the dials package.
-        Please report it at <https://github.com/tidymodels/dials/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
 
 ---
 
@@ -24,8 +22,6 @@
     Condition
       Error in `encode_unit()`:
       ! `value` should be a numeric vector.
-      i This is an internal error that was detected in the dials package.
-        Please report it at <https://github.com/tidymodels/dials/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
 
 ---
 
@@ -34,8 +30,6 @@
     Condition
       Error in `encode_unit()`:
       ! `value` should be a character vector.
-      i This is an internal error that was detected in the dials package.
-        Please report it at <https://github.com/tidymodels/dials/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
 
 ---
 
@@ -44,8 +38,6 @@
     Condition
       Error in `encode_unit()`:
       ! `value` should be a numeric vector.
-      i This is an internal error that was detected in the dials package.
-        Please report it at <https://github.com/tidymodels/dials/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
 
 ---
 
@@ -54,8 +46,6 @@
     Condition
       Error in `encode_unit()`:
       ! `value` should be a numeric vector.
-      i This is an internal error that was detected in the dials package.
-        Please report it at <https://github.com/tidymodels/dials/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
 
 ---
 
@@ -64,8 +54,6 @@
     Condition
       Error in `encode_unit()`:
       ! `value` should be a character vector.
-      i This is an internal error that was detected in the dials package.
-        Please report it at <https://github.com/tidymodels/dials/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
 
 ---
 
@@ -74,8 +62,6 @@
     Condition
       Error in `encode_unit()`:
       ! `value` should be a character vector.
-      i This is an internal error that was detected in the dials package.
-        Please report it at <https://github.com/tidymodels/dials/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
 
 ---
 
@@ -84,8 +70,6 @@
     Condition
       Error in `encode_unit()`:
       ! `value` should be a character vector.
-      i This is an internal error that was detected in the dials package.
-        Please report it at <https://github.com/tidymodels/dials/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
 
 ---
 
@@ -94,8 +78,6 @@
     Condition
       Error in `encode_unit()`:
       ! `value` should be a numeric vector.
-      i This is an internal error that was detected in the dials package.
-        Please report it at <https://github.com/tidymodels/dials/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
 
 ---
 
@@ -104,8 +86,6 @@
     Condition
       Error in `encode_unit()`:
       ! Values should be on [0, 1].
-      i This is an internal error that was detected in the dials package.
-        Please report it at <https://github.com/tidymodels/dials/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
 
 ---
 
@@ -114,8 +94,6 @@
     Condition
       Error in `encode_unit()`:
       ! Values should be on [0, 1].
-      i This is an internal error that was detected in the dials package.
-        Please report it at <https://github.com/tidymodels/dials/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
 
 ---
 
@@ -124,6 +102,4 @@
     Condition
       Error in `encode_unit()`:
       ! Values should be on [0, 1].
-      i This is an internal error that was detected in the dials package.
-        Please report it at <https://github.com/tidymodels/dials/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
 

--- a/tests/testthat/_snaps/encode_unit.md
+++ b/tests/testthat/_snaps/encode_unit.md
@@ -50,14 +50,6 @@
 ---
 
     Code
-      encode_unit(z, 1, direction = "forward")
-    Condition
-      Error in `encode_unit()`:
-      ! `value` should be a character vector.
-
----
-
-    Code
       encode_unit(z, matrix(1:4, ncol = 2), direction = "forward")
     Condition
       Error in `encode_unit()`:

--- a/tests/testthat/_snaps/encode_unit.md
+++ b/tests/testthat/_snaps/encode_unit.md
@@ -14,9 +14,8 @@
       encode_unit(z, prune_method()$values, direction = "forwards")
     Condition
       Error in `encode_unit()`:
-      ! `direction` should be either 'forward' or 'backward'
-      i This is an internal error that was detected in the dials package.
-        Please report it at <https://github.com/tidymodels/dials/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
+      ! `direction` must be one of "forward" or "backward", not "forwards".
+      i Did you mean "forward"?
 
 ---
 

--- a/tests/testthat/test-encode_unit.R
+++ b/tests/testthat/test-encode_unit.R
@@ -75,10 +75,6 @@ test_that("bad args", {
   )
   expect_snapshot(
     error = TRUE,
-    encode_unit(z, 1, direction = "forward")
-  )
-  expect_snapshot(
-    error = TRUE,
     encode_unit(z, matrix(1:4, ncol = 2), direction = "forward")
   )
   expect_snapshot(


### PR DESCRIPTION
Two changes:

- use `rlang::arg_match0()` for a better error message
- remove marking the other errors as internal - the functions are described as internal (which is probably the reason the errors got marked as internal) but they are also exported and the errors are not actually internal in the sense that this should never happen and thus be reported at the dials repo