### PR TITLE
Improved error handling for the constructor of parameter sets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,10 @@
 
 * Added `validation_set_prop()` for `embed::step_discretize_xgb()` (#280).
 
-* The constructor functions `new_quant_param()` and `new_qual_param()` now have improved handling of the call shown in error messages (#291).
+* The constructor functions for single parameters, `new_quant_param()` and `new_qual_param()`, as well as for parameter sets, `parameters_constr()`, now have improved handling of the call shown in error messages (#291, #295).
+
+* The constructor for parameter sets, `parameters_constr()`, now checks that all inputs have the same length (#295).
+
 
 # dials 1.1.0
 

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -98,6 +98,9 @@ check_list_of_param <- function(x, ..., call = caller_env()) {
 #' @param name,id,source,component,component_id Character strings with the same
 #' length.
 #' @param object A list of `param` objects or NA values.
+#' @inheritParams rlang::args_dots_empty
+#' @param call The call passed on to [rlang::abort()].
+#'
 #' @return A tibble that encapsulates the input vectors into a tibble with an
 #' additional class of "parameters".
 #' @keywords internal
@@ -107,14 +110,18 @@ parameters_constr <- function(name,
                               source,
                               component,
                               component_id,
-                              object) {
-  check_character(name)
-  check_character(id)
-  unique_check(id)
-  check_character(source)
-  check_character(component)
-  check_character(component_id)
-  check_list_of_param(object)
+                              object,
+                              ...,
+                              call = caller_env()) {
+  check_dots_empty()
+
+  check_character(name, call = call)
+  check_character(id, call = call)
+  unique_check(id, call = call)
+  check_character(source, call = call)
+  check_character(component, call = call)
+  check_character(component_id, call = call)
+  check_list_of_param(object, call = call)
 
   n_elements <- map_int(
     list(name, id, source, component, component_id, object),
@@ -122,7 +129,10 @@ parameters_constr <- function(name,
     )
   n_elements_unique <- unique(n_elements)
   if (length(n_elements_unique) > 1) {
-    abort("All inputs must contain contain the same number of elements.")
+    abort(
+      "All inputs must contain contain the same number of elements.",
+      call = call
+    )
   }
 
   res <-
@@ -140,7 +150,6 @@ parameters_constr <- function(name,
   class(res) <- c("parameters", class(res))
   res
 }
-
 
 unk_check <- function(x) {
   if (all(is.na(x))) {

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -54,24 +54,6 @@ parameters.list <- function(x, ...) {
   )
 }
 
-chr_check <- function(x, ..., call = caller_env()) {
-  check_dots_empty()
-  cl <- match.call()
-  if (is.null(x)) {
-    rlang::abort(
-      glue::glue("Element `{cl$x}` should not be NULL."),
-      call = call
-    )
-  }
-  if (!is.character(x)) {
-    rlang::abort(
-      glue::glue("Element `{cl$x}` should be a character string."),
-      call = call
-    )
-  }
-  invisible(TRUE)
-}
-
 unique_check <- function(x, ..., call = caller_env()) {
   check_dots_empty()
   x2 <- x[!is.na(x)]
@@ -108,12 +90,13 @@ parameters_constr <- function(name,
                               component,
                               component_id,
                               object) {
-  chr_check(name)
-  chr_check(id)
-  chr_check(source)
-  chr_check(component)
-  chr_check(component_id)
+  check_character(name)
+  check_character(id)
+  check_character(source)
+  check_character(component)
+  check_character(component_id)
   unique_check(id)
+
   if (is.null(object)) {
     rlang::abort("Element `object` should not be NULL.")
   }

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -115,6 +115,15 @@ parameters_constr <- function(name,
   check_character(component_id)
   check_list_of_param(object)
 
+  n_elements <- map_int(
+    list(name, id, source, component, component_id, object),
+    length
+    )
+  n_elements_unique <- unique(n_elements)
+  if (length(n_elements_unique) > 1) {
+    abort("All inputs must contain contain the same number of elements.")
+  }
+
   res <-
     new_tibble(
       list(

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -109,11 +109,10 @@ parameters_constr <- function(name,
                               object) {
   check_character(name)
   check_character(id)
+  unique_check(id)
   check_character(source)
   check_character(component)
   check_character(component_id)
-  unique_check(id)
-
   check_list_of_param(object)
 
   res <-

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -76,6 +76,7 @@ param_or_na <- function(x) {
 }
 
 check_list_of_param <- function(x, ..., call = caller_env()) {
+  check_dots_empty()
   if (!is.list(x)) {
     abort("`object` must be a list of `param` objects.", call = call)
   }

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -75,6 +75,23 @@ param_or_na <- function(x) {
   inherits(x, "param") | all(is.na(x))
 }
 
+check_list_of_param <- function(x, ..., call = caller_env()) {
+  if (!is.list(x)) {
+    abort("`object` must be a list of `param` objects.", call = call)
+  }
+  is_good_boi <- map_lgl(x, param_or_na)
+  if (any(!is_good_boi)) {
+    rlang::abort(
+      paste0(
+        "`object` elements in the following positions must be `NA` or a ",
+        "`param` object:",
+        paste0(which(!is_good_boi), collapse = ", ")
+      ),
+      call = call
+    )
+  }
+}
+
 #' Construct a new parameter set object
 #'
 #' @param name,id,source,component,component_id Character strings with the same
@@ -97,22 +114,8 @@ parameters_constr <- function(name,
   check_character(component_id)
   unique_check(id)
 
-  if (is.null(object)) {
-    rlang::abort("Element `object` should not be NULL.")
-  }
-  if (!is.list(object)) {
-    rlang::abort("`object` should be a list.")
-  }
-  is_good_boi <- map_lgl(object, param_or_na)
-  if (any(!is_good_boi)) {
-    rlang::abort(
-      paste0(
-        "`object` values in the following positions should be NA or a ",
-        "`param` object:",
-        paste0(which(!is_good_boi), collapse = ", ")
-      )
-    )
-  }
+  check_list_of_param(object)
+
   res <-
     new_tibble(
       list(

--- a/man/parameters_constr.Rd
+++ b/man/parameters_constr.Rd
@@ -4,13 +4,26 @@
 \alias{parameters_constr}
 \title{Construct a new parameter set object}
 \usage{
-parameters_constr(name, id, source, component, component_id, object)
+parameters_constr(
+  name,
+  id,
+  source,
+  component,
+  component_id,
+  object,
+  ...,
+  call = caller_env()
+)
 }
 \arguments{
 \item{name, id, source, component, component_id}{Character strings with the same
 length.}
 
 \item{object}{A list of \code{param} objects or NA values.}
+
+\item{...}{These dots are for future extensions and must be empty.}
+
+\item{call}{The call passed on to \code{\link[rlang:abort]{rlang::abort()}}.}
 }
 \value{
 A tibble that encapsulates the input vectors into a tibble with an

--- a/tests/testthat/_snaps/parameters.md
+++ b/tests/testthat/_snaps/parameters.md
@@ -1,3 +1,65 @@
+# parameters_const() input checks
+
+    Code
+      parameters_constr(2)
+    Condition
+      Error in `parameters_constr()`:
+      ! Element `name` should be a character string.
+
+---
+
+    Code
+      ab <- c("a", "b")
+      parameters_constr(ab, c("a", "a"), ab, ab, ab)
+    Condition
+      Error in `parameters_constr()`:
+      ! Element `id` should have unique values. Duplicates exist for item(s): 'a'
+
+---
+
+    Code
+      ab <- c("a", "b")
+      parameters_constr(ab, ab, ab, ab, ab, "not a params list")
+    Condition
+      Error in `parameters_constr()`:
+      ! `object` should be a list.
+
+---
+
+    Code
+      ab <- c("a", "b")
+      parameters_constr("a", ab, ab, ab, ab, list(penalty(), mtry()))
+    Output
+      Collection of 1 parameters for tuning
+      
+    Condition
+      Error in `$<-`:
+      ! Assigned data `purrr::map_chr(...)` must be compatible with existing data.
+      x Existing data has 1 row.
+      x Assigned data has 2 rows.
+      i Row updates require a list value. Do you need `list()` or `as.list()`?
+      Caused by error in `vectbl_recycle_rhs_rows()`:
+      ! Can't recycle input of size 2 to size 1.
+
+---
+
+    Code
+      ab <- c("a", "b")
+      parameters_constr(ab, ab, ab, ab, ab, list(penalty()))
+    Output
+      Collection of 2 parameters for tuning
+      
+       identifier type    object
+                a    a nparam[+]
+                b    b nparam[+]
+      
+    Condition
+      Error in `vec_slice()`:
+      ! Column `object` (size 1) must match the data frame (size 2).
+      i In file 'slice.c' at line 191.
+      i This is an internal error that was detected in the vctrs package.
+        Please report it at <https://github.com/r-lib/vctrs/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
+
 # create from lists of param objects
 
     Code

--- a/tests/testthat/_snaps/parameters.md
+++ b/tests/testthat/_snaps/parameters.md
@@ -22,7 +22,7 @@
       parameters_constr(ab, ab, ab, ab, ab, "not a params list")
     Condition
       Error in `parameters_constr()`:
-      ! `object` should be a list.
+      ! `object` must be a list of `param` objects.
 
 ---
 

--- a/tests/testthat/_snaps/parameters.md
+++ b/tests/testthat/_snaps/parameters.md
@@ -3,7 +3,7 @@
     Code
       parameters_constr(2)
     Condition
-      Error in `parameters_constr()`:
+      Error:
       ! `name` must be a character vector, not the number 2.
 
 ---
@@ -12,7 +12,7 @@
       ab <- c("a", "b")
       parameters_constr(ab, c("a", "a"), ab, ab, ab)
     Condition
-      Error in `parameters_constr()`:
+      Error:
       ! Element `id` should have unique values. Duplicates exist for item(s): 'a'
 
 ---
@@ -21,7 +21,7 @@
       ab <- c("a", "b")
       parameters_constr(ab, ab, ab, ab, ab, "not a params list")
     Condition
-      Error in `parameters_constr()`:
+      Error:
       ! `object` must be a list of `param` objects.
 
 ---
@@ -30,7 +30,7 @@
       ab <- c("a", "b")
       parameters_constr("a", ab, ab, ab, ab, list(penalty(), mtry()))
     Condition
-      Error in `parameters_constr()`:
+      Error:
       ! All inputs must contain contain the same number of elements.
 
 ---
@@ -39,7 +39,7 @@
       ab <- c("a", "b")
       parameters_constr(ab, ab, ab, ab, ab, list(penalty()))
     Condition
-      Error in `parameters_constr()`:
+      Error:
       ! All inputs must contain contain the same number of elements.
 
 # create from lists of param objects
@@ -47,7 +47,7 @@
     Code
       parameters(list(a = mtry(), a = penalty()))
     Condition
-      Error in `parameters_constr()`:
+      Error in `parameters()`:
       ! Element `id` should have unique values. Duplicates exist for item(s): 'a'
 
 # updating

--- a/tests/testthat/_snaps/parameters.md
+++ b/tests/testthat/_snaps/parameters.md
@@ -4,7 +4,7 @@
       parameters_constr(2)
     Condition
       Error in `parameters_constr()`:
-      ! Element `name` should be a character string.
+      ! `name` must be a character vector, not the number 2.
 
 ---
 

--- a/tests/testthat/_snaps/parameters.md
+++ b/tests/testthat/_snaps/parameters.md
@@ -29,36 +29,18 @@
     Code
       ab <- c("a", "b")
       parameters_constr("a", ab, ab, ab, ab, list(penalty(), mtry()))
-    Output
-      Collection of 1 parameters for tuning
-      
     Condition
-      Error in `$<-`:
-      ! Assigned data `purrr::map_chr(...)` must be compatible with existing data.
-      x Existing data has 1 row.
-      x Assigned data has 2 rows.
-      i Row updates require a list value. Do you need `list()` or `as.list()`?
-      Caused by error in `vectbl_recycle_rhs_rows()`:
-      ! Can't recycle input of size 2 to size 1.
+      Error in `parameters_constr()`:
+      ! All inputs must contain contain the same number of elements.
 
 ---
 
     Code
       ab <- c("a", "b")
       parameters_constr(ab, ab, ab, ab, ab, list(penalty()))
-    Output
-      Collection of 2 parameters for tuning
-      
-       identifier type    object
-                a    a nparam[+]
-                b    b nparam[+]
-      
     Condition
-      Error in `vec_slice()`:
-      ! Column `object` (size 1) must match the data frame (size 2).
-      i In file 'slice.c' at line 191.
-      i This is an internal error that was detected in the vctrs package.
-        Please report it at <https://github.com/r-lib/vctrs/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
+      Error in `parameters_constr()`:
+      ! All inputs must contain contain the same number of elements.
 
 # create from lists of param objects
 

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -1,3 +1,24 @@
+test_that("parameters_const() input checks", {
+  expect_snapshot(error = TRUE, {
+    parameters_constr(2)
+  })
+  expect_snapshot(error = TRUE, {
+    ab <- c("a", "b")
+    parameters_constr(ab, c("a", "a"), ab, ab, ab)
+  })
+  expect_snapshot(error = TRUE, {
+    ab <- c("a", "b")
+    parameters_constr(ab, ab, ab, ab, ab, "not a params list")
+  })
+  expect_snapshot(error = TRUE, {
+    ab <- c("a", "b")
+    parameters_constr("a", ab, ab, ab, ab, list(penalty(), mtry()))
+  })
+  expect_snapshot(error = TRUE, {
+    ab <- c("a", "b")
+    parameters_constr(ab, ab, ab, ab, ab, list(penalty()))
+  })
+})
 
 test_that("create from param objects", {
   expect_error(p_1 <- parameters(mtry(), penalty()), NA)


### PR DESCRIPTION
The checks inside the constructor `parameters_constr()` now

- use rlang's type checker for a character vector
- check that inputs have the same size (which was requested in the docs)
- pass the call along