### PR TITLE
Fix test on `value_sample()`

### DIFF
--- a/tests/testthat/test-aaa_values.R
+++ b/tests/testthat/test-aaa_values.R
@@ -211,10 +211,8 @@ test_that("sampling - integers", {
   expect_true(max(p2_tran) < test_param_2$range$upper)
   expect_true(!is.integer(p2_tran))
 
-  expect_equal(
-    sort(unique(value_sample(int_seq, 50))),
-    int_seq$values
-  )
+  int_sampled_values <- sort(unique(value_sample(int_seq, 50)))
+  expect_true(all(int_sampled_values %in% int_seq$values))
 })
 
 


### PR DESCRIPTION
This test failure was rare but 50 values is not enough to _always_ cover the full sequence, so now it tests that the values drawn are a subset of the initial values.

Example of the failure: https://github.com/tidymodels/dials/actions/runs/4575428767/jobs/8078246351?pr=296