### PR TITLE
Deprecated grid methods for workflows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@
 
 * The constructor for parameter sets, `parameters_constr()`, now checks that all inputs have the same length (#295).
 
+* The methods `grid_regular.workflow()`, `grid_random.workflow()`, `grid_max_entropy.workflow()`, and `grid_latin_hypercube.workflow()` have been deprecated.
+
 
 # dials 1.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@
 
 * The constructor for parameter sets, `parameters_constr()`, now checks that all inputs have the same length (#295).
 
-* The methods `grid_regular.workflow()`, `grid_random.workflow()`, `grid_max_entropy.workflow()`, and `grid_latin_hypercube.workflow()` have been deprecated.
+* The methods `grid_regular.workflow()`, `grid_random.workflow()`, `grid_max_entropy.workflow()`, and `grid_latin_hypercube.workflow()` have been deprecated (#302).
 
 
 # dials 1.1.0

--- a/R/grids.R
+++ b/R/grids.R
@@ -123,13 +123,7 @@ grid_regular.workflow <- function(x,
                                   levels = 3,
                                   original = TRUE,
                                   filter = NULL) {
-  grid_regular.parameters(
-    parameters(x),
-    ...,
-    levels = levels,
-    original = original,
-    filter = {{ filter }}
-  )
+  lifecycle::deprecate_stop(when = "1.2.0", what = "grid_regular.workflow()")
 }
 
 make_regular_grid <- function(...,
@@ -247,13 +241,7 @@ grid_random.param <- function(x, ..., size = 5, original = TRUE, filter = NULL) 
 #' @export
 #' @rdname grid_regular
 grid_random.workflow <- function(x, ..., size = 5, original = TRUE, filter = NULL) {
-  grid_random.parameters(
-    parameters(x),
-    ...,
-    size = size,
-    original = original,
-    filter = {{ filter }}
-  )
+  lifecycle::deprecate_stop(when = "1.2.0", what = "grid_random.workflow()")
 }
 
 

--- a/R/grids.R
+++ b/R/grids.R
@@ -123,7 +123,11 @@ grid_regular.workflow <- function(x,
                                   levels = 3,
                                   original = TRUE,
                                   filter = NULL) {
-  lifecycle::deprecate_stop(when = "1.2.0", what = "grid_regular.workflow()")
+  lifecycle::deprecate_stop(
+    when = "1.2.0",
+    what = "grid_regular.workflow()",
+    details = "Alternatively, first extract the parameter set with `extract_parameter_set_dials()`, then create the grid from that object."
+  )
 }
 
 make_regular_grid <- function(...,
@@ -241,7 +245,11 @@ grid_random.param <- function(x, ..., size = 5, original = TRUE, filter = NULL) 
 #' @export
 #' @rdname grid_regular
 grid_random.workflow <- function(x, ..., size = 5, original = TRUE, filter = NULL) {
-  lifecycle::deprecate_stop(when = "1.2.0", what = "grid_random.workflow()")
+  lifecycle::deprecate_stop(
+    when = "1.2.0",
+    what = "grid_random.workflow()",
+    details = "Alternatively, first extract the parameter set with `extract_parameter_set_dials()`, then create the grid from that object."
+  )
 }
 
 

--- a/R/space_filling.R
+++ b/R/space_filling.R
@@ -111,14 +111,7 @@ grid_max_entropy.param <- function(x, ..., size = 3, original = TRUE,
 #' @rdname grid_max_entropy
 grid_max_entropy.workflow <- function(x, ..., size = 3, original = TRUE,
                                       variogram_range = 0.5, iter = 1000) {
-  grid_max_entropy.parameters(
-    parameters(x),
-    ...,
-    size = size,
-    original = original,
-    variogram_range = variogram_range,
-    iter = iter
-  )
+  lifecycle::deprecate_stop(when = "1.2.0", what = "grid_max_entropy.workflow()")
 }
 
 
@@ -210,7 +203,7 @@ grid_latin_hypercube.param <- function(x, ..., size = 3, original = TRUE) {
 #' @export
 #' @rdname grid_max_entropy
 grid_latin_hypercube.workflow <- function(x, ..., size = 3, original = TRUE) {
-  grid_latin_hypercube.parameters(parameters(x), ..., size = size, original = original)
+  lifecycle::deprecate_stop(when = "1.2.0", what = "grid_latin_hypercube.workflow()")
 }
 
 

--- a/R/space_filling.R
+++ b/R/space_filling.R
@@ -111,7 +111,11 @@ grid_max_entropy.param <- function(x, ..., size = 3, original = TRUE,
 #' @rdname grid_max_entropy
 grid_max_entropy.workflow <- function(x, ..., size = 3, original = TRUE,
                                       variogram_range = 0.5, iter = 1000) {
-  lifecycle::deprecate_stop(when = "1.2.0", what = "grid_max_entropy.workflow()")
+  lifecycle::deprecate_stop(
+    when = "1.2.0",
+    what = "grid_max_entropy.workflow()",
+    details = "Alternatively, first extract the parameter set with `extract_parameter_set_dials()`, then create the grid from that object."
+  )
 }
 
 
@@ -203,7 +207,11 @@ grid_latin_hypercube.param <- function(x, ..., size = 3, original = TRUE) {
 #' @export
 #' @rdname grid_max_entropy
 grid_latin_hypercube.workflow <- function(x, ..., size = 3, original = TRUE) {
-  lifecycle::deprecate_stop(when = "1.2.0", what = "grid_latin_hypercube.workflow()")
+  lifecycle::deprecate_stop(
+    when = "1.2.0",
+    what = "grid_latin_hypercube.workflow()",
+    details = "Alternatively, first extract the parameter set with `extract_parameter_set_dials()`, then create the grid from that object."
+  )
 }
 
 


### PR DESCRIPTION
closes #299

@simonpcouch Do you think it would be useful to keep these methods around? Or be less swift with the deprecation?

We don't seem to have missed them when they broke and all they do is save you one step of extracting the parameter set from the workflow. But we could also stash them in {workflows} if you think they are worth keeping.