### PR TITLE
return early when possible in `check_for_unknowns()`

### DIFF
--- a/R/aaa_unknown.R
+++ b/R/aaa_unknown.R
@@ -82,6 +82,9 @@ has_unknowns_val <- function(object) {
 
 check_for_unknowns <- function(x, ..., call = caller_env()) {
   check_dots_empty()
+  if (is.atomic(x)) {
+    return(invisible(TRUE))
+  }
   if (length(x) == 1 && is_unknown(x)) {
     rlang::abort("Unknowns not allowed.", call = call)
   }


### PR DESCRIPTION
Since `quote(unknown())` is a `"call"`, `is.atomic()` on `quote(unknown())` or any object containing it will be `FALSE`. This saves a good bit of time:

``` r
x <- c(1, unknown())

bench::mark(
  map_is_unknown_val = any(map_lgl(x, dials:::is_unknown_val)),
  is_atomic = !is.atomic(x)
) %>%
  select(expression, median, mem_alloc)
#> # A tibble: 2 × 3
#>   expression           median mem_alloc
#>   <bch:expr>         <bch:tm> <bch:byt>
#> 1 map_is_unknown_val   86.1µs     201KB
#> 2 is_atomic              41ns        0B
```

I added this early return and opted not to make any other changes, though folks with a better understanding of the situations where this ends up used might have a better sense for whether we can trim out any of the remaining body of `check_for_unknowns()`. :)
