### PR TITLE
Use expect_in() for weaker but surer test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Suggests:
     knitr,
     rmarkdown,
     rpart,
-    testthat (>= 3.0.0),
+    testthat (>= 3.1.9),
     xml2
 VignetteBuilder: 
     knitr

--- a/tests/testthat/test-aaa_values.R
+++ b/tests/testthat/test-aaa_values.R
@@ -171,10 +171,8 @@ test_that("sampling - doubles", {
   expect_true(min(L2_tran) > penalty()$range$lower)
   expect_true(max(L2_tran) < penalty()$range$upper)
 
-  expect_equal(
-    sort(unique(value_sample(value_seq, 40))),
-    value_seq$values
-  )
+  sampled_values <- unique(value_sample(value_seq, 40))
+  expect_in(sampled_values, value_seq$values)
 })
 
 test_that("sampling - integers", {
@@ -211,8 +209,8 @@ test_that("sampling - integers", {
   expect_true(max(p2_tran) < test_param_2$range$upper)
   expect_true(!is.integer(p2_tran))
 
-  int_sampled_values <- sort(unique(value_sample(int_seq, 50)))
-  expect_true(all(int_sampled_values %in% int_seq$values))
+  int_sampled_values <- unique(value_sample(int_seq, 50))
+  expect_in(int_sampled_values, int_seq$values)
 })
 
 

--- a/tests/testthat/test-aaa_values.R
+++ b/tests/testthat/test-aaa_values.R
@@ -260,11 +260,13 @@ test_that("sequences - logical", {
 
 
 test_that("sampling - character and logical", {
-  expect_equal(
-    sort(unique(value_sample(surv_dist(), 500))), sort(surv_dist()$values)
+  expect_in(
+    unique(value_sample(surv_dist(), 500)), 
+    surv_dist()$values
   )
-  expect_equal(
-    sort(unique(value_sample(prune(), 500))), sort(prune()$values)
+  expect_in(
+    unique(value_sample(prune(), 500)),
+    prune()$values
   )
 })
 

--- a/tests/testthat/test-aaa_values.R
+++ b/tests/testthat/test-aaa_values.R
@@ -171,8 +171,7 @@ test_that("sampling - doubles", {
   expect_true(min(L2_tran) > penalty()$range$lower)
   expect_true(max(L2_tran) < penalty()$range$upper)
 
-  sampled_values <- unique(value_sample(value_seq, 40))
-  expect_in(sampled_values, value_seq$values)
+  expect_in(value_sample(value_seq, 40), value_seq$values)
 })
 
 test_that("sampling - integers", {
@@ -209,8 +208,7 @@ test_that("sampling - integers", {
   expect_true(max(p2_tran) < test_param_2$range$upper)
   expect_true(!is.integer(p2_tran))
 
-  int_sampled_values <- unique(value_sample(int_seq, 50))
-  expect_in(int_sampled_values, int_seq$values)
+  expect_in(value_sample(int_seq, 50), int_seq$values)
 })
 
 
@@ -260,14 +258,8 @@ test_that("sequences - logical", {
 
 
 test_that("sampling - character and logical", {
-  expect_in(
-    unique(value_sample(surv_dist(), 500)), 
-    surv_dist()$values
-  )
-  expect_in(
-    unique(value_sample(prune(), 500)),
-    prune()$values
-  )
+  expect_in(value_sample(surv_dist(), 500), surv_dist()$values)
+  expect_in(value_sample(prune(), 500), prune()$values)
 })
 
 test_that("validate unknowns", {


### PR DESCRIPTION
Follow-up to #309.

I also saw these tests using `sort(unique())`, but I don't have enough context to know whether it's preferable to switch those to `expect_in()` as well:

https://github.com/tidymodels/dials/blob/55763e0cbd49a16a3f5a532dc92b9069258d54e7/tests/testthat/test-aaa_values.R#L264-L271