### PR TITLE
Use rlang to check for installed packages

### DIFF
--- a/R/finalize.R
+++ b/R/finalize.R
@@ -248,7 +248,7 @@ get_n <- function(object, x, log_vals = FALSE, ...) {
 #' @export
 #' @rdname finalize
 get_rbf_range <- function(object, x, seed = sample.int(10^5, 1), ...) {
-  check_installs("kernlab")
+  rlang::check_installed("kernlab")
   suppressPackageStartupMessages(requireNamespace("kernlab", quietly = TRUE))
   x_mat <- as.matrix(x)
   if (!is.numeric(x_mat)) {

--- a/R/misc.R
+++ b/R/misc.R
@@ -33,20 +33,6 @@ format_bounds <- function(bnds) {
   res
 }
 
-# From parsnip:::check_installs
-check_installs <- function(x) {
-  lib_inst <- rownames(installed.packages())
-  is_inst <- x %in% lib_inst
-  if (any(!is_inst)) {
-    rlang::abort(
-      paste0(
-        "Package(s) not installed: ",
-        paste0("'", x[!is_inst], "'", collapse = ", ")
-      )
-    )
-  }
-}
-
 # checking functions -----------------------------------------------------------
 
 check_label <- function(label, ..., call = caller_env()) {

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -1,12 +1,4 @@
 
-test_that("package install checks", {
-  expect_snapshot(error = TRUE, dials:::check_installs("pistachio"))
-  expect_error(
-    dials:::check_installs("dials"),
-    NA
-  )
-})
-
 test_that("formatting", {
   expect_equal(
     dials:::format_bounds(c(TRUE, TRUE)),


### PR DESCRIPTION
instead of the custom version. Added benefit: the rlang version prompts you to install the missing package, if used interactively.