### PR TITLE
link docs for `encode_unit()`

### DIFF
--- a/R/encode_unit.R
+++ b/R/encode_unit.R
@@ -7,8 +7,8 @@
 #' @param value The original values should be either numeric or character. When
 #'  converting back, these should be on \code{[0, 1]}.
 #' @param direction Either "forward" (to \code{[0, 1]}) or "backward".
-#' @param original A logical; should the values be transformed into their natural
-#'  units (not currently working).
+#' @param original A logical; should the values be transformed into their 
+#' natural units.
 #' @details For integer parameters, the encoding can be lossy.
 #' @return A vector of values.
 #' @keywords internal
@@ -23,6 +23,7 @@ encode_unit.default <- function(x, value, direction, ...) {
   rlang::abort("`x` should be a dials parameter object.")
 }
 
+#' @rdname encode_unit
 #' @export
 encode_unit.quant_param <- function(x, value, direction, original = TRUE, ...) {
   if (has_unknowns(x)) {
@@ -34,6 +35,7 @@ encode_unit.quant_param <- function(x, value, direction, original = TRUE, ...) {
   }
 
   param_rng <- x$range$upper - x$range$lower
+
   if (direction == "forward") {
     # convert to [0, 1]
     value <- (value - x$range$lower) / param_rng
@@ -61,6 +63,7 @@ encode_unit.quant_param <- function(x, value, direction, original = TRUE, ...) {
   value
 }
 
+#' @rdname encode_unit
 #' @export
 encode_unit.qual_param <- function(x, value, direction, ...) {
   if (has_unknowns(x)) {

--- a/man/encode_unit.Rd
+++ b/man/encode_unit.Rd
@@ -2,9 +2,15 @@
 % Please edit documentation in R/encode_unit.R
 \name{encode_unit}
 \alias{encode_unit}
+\alias{encode_unit.quant_param}
+\alias{encode_unit.qual_param}
 \title{Class for converting parameter values back and forth to the unit range}
 \usage{
 encode_unit(x, value, direction, ...)
+
+\method{encode_unit}{quant_param}(x, value, direction, original = TRUE, ...)
+
+\method{encode_unit}{qual_param}(x, value, direction, ...)
 }
 \arguments{
 \item{x}{A \code{param} object.}
@@ -14,8 +20,8 @@ converting back, these should be on \code{[0, 1]}.}
 
 \item{direction}{Either "forward" (to \code{[0, 1]}) or "backward".}
 
-\item{original}{A logical; should the values be transformed into their natural
-units (not currently working).}
+\item{original}{A logical; should the values be transformed into their
+natural units.}
 }
 \value{
 A vector of values.


### PR DESCRIPTION
fixes #320 

This connectes the documentation for the generic (without the `original` argument) and the S3 method of quantitative parameters (with the `original` argument) so that we don't document an "unused" argument anymore.

The argument `original` was documented as "not currently working" so I was considering removing it, rather than changing the documentation, and did some github archeology. 

The documentation is from https://github.com/tidymodels/dials/commit/ae4e9008d5d03ff7fe37cc892be2bdfeb113c278. 

The state of the function then had a code comment about missing the inverse transformation and https://github.com/tidymodels/dials/issues/54. That comes "for free" with the scales package though, so it was included in https://github.com/tidymodels/dials/commit/198384b2c0b9c71e5c1949167dffb579592d47de. That commit didn't include an update to the docs but I think it has been working as intended from then on, so I've updated the docs accordingly. 