### PR TITLE
Improve discoverablity of preprocessing parameters

### DIFF
--- a/R/param_min_unique.R
+++ b/R/param_min_unique.R
@@ -1,7 +1,7 @@
 #' Number of unique values for pre-processing
 #'
 #' Some pre-processing parameters require a minimum number of unique data points
-#' to proceed.
+#' to proceed. Used in `recipes::step_discretize()`.
 #'
 #' @inheritParams Laplace
 #' @examples

--- a/R/param_num_breaks.R
+++ b/R/param_num_breaks.R
@@ -1,6 +1,7 @@
 #' Number of cut-points for binning
 #'
-#' This parameter controls how many bins are used when discretizing predictors.
+#' This parameter controls how many bins are used when discretizing predictors. 
+#' Used in `recipes::step_discretize()` and `embed::step_discretize_xgb()`.
 #'
 #' @inheritParams Laplace
 #' @examples

--- a/R/param_num_hash.R
+++ b/R/param_num_hash.R
@@ -1,6 +1,6 @@
 #' Text hashing parameters
 #'
-#' Used in `textrecipes::step_texthash()`.
+#' Used in `textrecipes::step_texthash()` and `textrecipes::step_dummy_hash()`.
 #'
 #' @inheritParams Laplace
 #' @param values	A vector of possible values (TRUE or FALSE).

--- a/R/param_over_ratio.R
+++ b/R/param_over_ratio.R
@@ -1,12 +1,11 @@
 #' Parameters for class-imbalance sampling
 #'
 #' For up- and down-sampling methods, these parameters control how much data are
-#' added or removed from the training set.
+#' added or removed from the training set. Used in `themis::step_rose()`, 
+#' `themis::step_smotenc()`, `themis::step_bsmote()`, `themis::step_upsample()`, 
+#' `themis::step_downsample()`, and `themis::step_nearmiss()`.
 #'
 #' @inheritParams Laplace
-#' @details
-#' See `recipes::step_upsample()` and `recipes::step_downsample()` for the
-#' interpretation of these parameters.
 #' @examples
 #' under_ratio()
 #' over_ratio()

--- a/R/param_window_size.R
+++ b/R/param_window_size.R
@@ -1,6 +1,6 @@
 #' Parameter for the moving window size
 #'
-#' Used in `recipes::step_window()`.
+#' Used in `recipes::step_window()` and `recipes::step_impute_roll()`.
 #'
 #' @inheritParams Laplace
 #' @examples

--- a/man/min_unique.Rd
+++ b/man/min_unique.Rd
@@ -18,7 +18,7 @@ transformation, \code{NULL}.}
 }
 \description{
 Some pre-processing parameters require a minimum number of unique data points
-to proceed.
+to proceed. Used in \code{recipes::step_discretize()}.
 }
 \examples{
 min_unique()

--- a/man/num_breaks.Rd
+++ b/man/num_breaks.Rd
@@ -18,6 +18,7 @@ transformation, \code{NULL}.}
 }
 \description{
 This parameter controls how many bins are used when discretizing predictors.
+Used in \code{recipes::step_discretize()} and \code{embed::step_discretize_xgb()}.
 }
 \examples{
 num_breaks()

--- a/man/over_ratio.Rd
+++ b/man/over_ratio.Rd
@@ -21,11 +21,9 @@ transformation, \code{NULL}.}
 }
 \description{
 For up- and down-sampling methods, these parameters control how much data are
-added or removed from the training set.
-}
-\details{
-See \code{recipes::step_upsample()} and \code{recipes::step_downsample()} for the
-interpretation of these parameters.
+added or removed from the training set. Used in \code{themis::step_rose()},
+\code{themis::step_smotenc()}, \code{themis::step_bsmote()}, \code{themis::step_upsample()},
+\code{themis::step_downsample()}, and \code{themis::step_nearmiss()}.
 }
 \examples{
 under_ratio()

--- a/man/texthash.Rd
+++ b/man/texthash.Rd
@@ -22,7 +22,7 @@ transformation, \code{NULL}.}
 \item{values}{A vector of possible values (TRUE or FALSE).}
 }
 \description{
-Used in \code{textrecipes::step_texthash()}.
+Used in \code{textrecipes::step_texthash()} and \code{textrecipes::step_dummy_hash()}.
 }
 \examples{
 num_hash()

--- a/man/window_size.Rd
+++ b/man/window_size.Rd
@@ -17,7 +17,7 @@ the default is used which matches the units used in \code{range}. If no
 transformation, \code{NULL}.}
 }
 \description{
-Used in \code{recipes::step_window()}.
+Used in \code{recipes::step_window()} and \code{recipes::step_impute_roll()}.
 }
 \examples{
 window_size()


### PR DESCRIPTION
so that you can search for a step name on dials' pkgdown site and find the corresponding dials parameter