### PR TITLE
Switch from `rlang::abort()` in `parameters.R`, `grids.R` and `misc.R`

### DIFF
--- a/R/grids.R
+++ b/R/grids.R
@@ -157,7 +157,7 @@ make_regular_grid <- function(...,
     parameters <- dplyr::filter(parameters, !!filter_quo)
   }
 
-  new_param_grid(parameters)
+  new_param_grid(parameters, call = call)
 }
 
 # ------------------------------------------------------------------------------
@@ -246,12 +246,12 @@ make_random_grid <- function(...,
     parameters <- dplyr::filter(parameters, !!filter_quo)
   }
 
-  new_param_grid(parameters)
+  new_param_grid(parameters, call = call)
 }
 
 # ------------------------------------------------------------------------------
 
-new_param_grid <- function(x = new_data_frame()) {
+new_param_grid <- function(x = new_data_frame(), call = caller_env()) {
   if (!is.data.frame(x)) {
     cli::cli_abort(
       "{.arg x} must be a data frame to construct a new grid from."

--- a/R/grids.R
+++ b/R/grids.R
@@ -130,8 +130,8 @@ make_regular_grid <- function(...,
   # check levels
   p <- length(levels)
   if (p > 1 && p != length(param_quos)) {
-    rlang::abort(
-      paste0("`levels` should have length 1 or ", length(param_quos)),
+    cli::cli_abort(
+      "{.arg levels} should have length 1 or {length(param_quos)}, not {p}.",
       call = call
     )
   }
@@ -142,8 +142,9 @@ make_regular_grid <- function(...,
     if (all(rlang::has_name(levels, names(params)))) {
       levels <- levels[names(params)]
     } else if (any(rlang::has_name(levels, names(params)))) {
-      rlang::abort(
-        "Elements of `levels` should either be all named or unnamed, not mixed.",
+      cli::cli_abort(
+        "Elements of {.arg levels} should either be all named or unnamed, 
+        not mixed.",
         call = call
       )
     }
@@ -252,7 +253,9 @@ make_random_grid <- function(...,
 
 new_param_grid <- function(x = new_data_frame()) {
   if (!is.data.frame(x)) {
-    rlang::abort("`x` must be a data frame to construct a new grid from.")
+    cli::cli_abort(
+      "{.arg x} must be a data frame to construct a new grid from."
+    )
   }
 
   x <- vctrs::vec_unique(x)

--- a/R/misc.R
+++ b/R/misc.R
@@ -70,20 +70,21 @@ check_range <- function(x, type, trans, ..., call = caller_env()) {
       whole <-
         purrr::map_lgl(x0[known], ~ abs(.x - round(.x)) < .Machine$double.eps^0.5)
       if (!all(whole)) {
-        msg <- paste(x0[known][!whole], collapse = ", ")
-        msg <- paste0(
-          "An integer is required for the range and these do not appear to be ",
-          "whole numbers: ", msg
+        offenders <- x0[known][!whole]
+        cli::cli_abort(
+          "An integer is required for the range and these do not appear to be
+          whole numbers: {offenders}.",
+          call = call
         )
-        rlang::abort(msg, call = call)
       }
 
       x0[known] <- as.integer(x0[known])
     } else {
-      msg <- paste0(
-        "Since `type = '", type, "'`, please use that data type for the range."
+      cli::cli_abort(
+        "Since {.code type = \"{type}\"}, please use that data type for the 
+        range.",
+        call = call
       )
-      rlang::abort(msg, call = call)
     }
   }
   invisible(x0)
@@ -97,13 +98,13 @@ check_values_quant <- function(x, ..., call = caller_env()) {
   }
 
   if (!is.numeric(x)) {
-    rlang::abort("`values` must be numeric.", call = call)
+    cli::cli_abort("{.arg values} must be numeric.", call = call)
   }
   if (anyNA(x)) {
-    rlang::abort("`values` can't be `NA`.", call = call)
+    cli::cli_abort("{.arg values} can't be {.code NA}.", call = call)
   }
   if (length(x) == 0) {
-    rlang::abort("`values` can't be empty.", call = call)
+    cli::cli_abort("{.arg values} can't be empty.", call = call)
   }
 
   invisible(x)

--- a/R/space_filling.R
+++ b/R/space_filling.R
@@ -235,7 +235,7 @@ make_sfd <- function(...,
       )
   }
 
-  new_param_grid(grid)
+  new_param_grid(grid, call = call)
 }
 
 base_recycle <- function(x, size) {

--- a/man/parameters_constr.Rd
+++ b/man/parameters_constr.Rd
@@ -23,7 +23,7 @@ length.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
-\item{call}{The call passed on to \code{\link[rlang:abort]{rlang::abort()}}.}
+\item{call}{The call passed on to \code{\link[cli:cli_abort]{cli::cli_abort()}}.}
 }
 \value{
 A tibble that encapsulates the input vectors into a tibble with an

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -170,7 +170,7 @@
       mixture(c(1L, 3L))
     Condition
       Error in `mixture()`:
-      ! Since `type = 'double'`, please use that data type for the range.
+      ! Since `type = "double"`, please use that data type for the range.
 
 ---
 
@@ -178,7 +178,7 @@
       mixture(c(1L, unknown()))
     Condition
       Error in `mixture()`:
-      ! Since `type = 'double'`, please use that data type for the range.
+      ! Since `type = "double"`, please use that data type for the range.
 
 ---
 
@@ -186,7 +186,7 @@
       mixture(c(unknown(), 1L))
     Condition
       Error in `mixture()`:
-      ! Since `type = 'double'`, please use that data type for the range.
+      ! Since `type = "double"`, please use that data type for the range.
 
 ---
 
@@ -194,7 +194,7 @@
       mixture(letters[1:2])
     Condition
       Error in `mixture()`:
-      ! Since `type = 'double'`, please use that data type for the range.
+      ! Since `type = "double"`, please use that data type for the range.
 
 ---
 
@@ -202,7 +202,7 @@
       mtry(c(0.1, 0.5))
     Condition
       Error in `mtry()`:
-      ! An integer is required for the range and these do not appear to be whole numbers: 0.1, 0.5
+      ! An integer is required for the range and these do not appear to be whole numbers: 0.1 and 0.5.
 
 ---
 
@@ -210,7 +210,7 @@
       mtry(c(0.1, unknown()))
     Condition
       Error in `mtry()`:
-      ! An integer is required for the range and these do not appear to be whole numbers: 0.1
+      ! An integer is required for the range and these do not appear to be whole numbers: 0.1.
 
 ---
 
@@ -218,7 +218,7 @@
       mtry(c(unknown(), 0.5))
     Condition
       Error in `mtry()`:
-      ! An integer is required for the range and these do not appear to be whole numbers: 0.5
+      ! An integer is required for the range and these do not appear to be whole numbers: 0.5.
 
 # `values` must be compatible with `range` and `inclusive`
 

--- a/tests/testthat/_snaps/grids.md
+++ b/tests/testthat/_snaps/grids.md
@@ -4,7 +4,7 @@
       grid_regular(mixture(), trees(), levels = 1:4)
     Condition
       Error in `grid_regular()`:
-      ! `levels` should have length 1 or 2
+      ! `levels` should have length 1 or 2, not 4.
 
 ---
 

--- a/tests/testthat/_snaps/grids.md
+++ b/tests/testthat/_snaps/grids.md
@@ -14,7 +14,7 @@
       Warning:
       `size` is not an argument to `grid_regular()`. Did you mean `levels`?
       Error in `parameters()`:
-      ! The objects should all be `param` objects.
+      ! The objects should all be <param> objects.
 
 # wrong argument name
 

--- a/tests/testthat/_snaps/grids.md
+++ b/tests/testthat/_snaps/grids.md
@@ -16,6 +16,14 @@
       Error in `parameters()`:
       ! The objects should all be <param> objects.
 
+---
+
+    Code
+      grid_regular(mixture(), trees(), levels = c(2, trees = 4))
+    Condition
+      Error in `grid_regular()`:
+      ! Elements of `levels` should either be all named or unnamed, not mixed.
+
 # wrong argument name
 
     Code

--- a/tests/testthat/_snaps/parameters.md
+++ b/tests/testthat/_snaps/parameters.md
@@ -13,7 +13,8 @@
       parameters_constr(ab, c("a", "a"), ab, ab, ab)
     Condition
       Error:
-      ! Element `id` should have unique values. Duplicates exist for item(s): 'a'
+      x Element id should have unique values.
+      i Duplicates exist for item: a
 
 ---
 
@@ -22,7 +23,7 @@
       parameters_constr(ab, ab, ab, ab, ab, "not a params list")
     Condition
       Error:
-      ! `object` must be a list of `param` objects.
+      ! `object` must be a list of <param> objects.
 
 ---
 
@@ -48,7 +49,8 @@
       parameters(list(a = mtry(), a = penalty()))
     Condition
       Error in `parameters()`:
-      ! Element `id` should have unique values. Duplicates exist for item(s): 'a'
+      x Element id should have unique values.
+      i Duplicates exist for item: a
 
 # updating
 
@@ -142,5 +144,5 @@
       parameters(tibble::as_tibble(mtcars))
     Condition
       Error in `parameters()`:
-      ! `parameters` objects cannot be created from objects of class `tbl_df`.
+      ! <parameters> objects cannot be created from a tibble.
 

--- a/tests/testthat/_snaps/parameters.md
+++ b/tests/testthat/_snaps/parameters.md
@@ -52,6 +52,14 @@
       x Element id should have unique values.
       i Duplicates exist for item: a
 
+---
+
+    Code
+      parameters(list(a = mtry, a = penalty()))
+    Condition
+      Error in `parameters()`:
+      ! The objects should all be <param> objects.
+
 # updating
 
     Code
@@ -71,10 +79,26 @@
 ---
 
     Code
+      update(p_1, not_penalty = 1:2)
+    Condition
+      Error in `update()`:
+      ! At least one parameter does not match any id's in the set: not_penalty.
+
+---
+
+    Code
       update(p_1, penalty(), mtry = mtry(3:4))
     Condition
       Error in `update()`:
       ! All arguments should be named.
+
+---
+
+    Code
+      update(p_1)
+    Condition
+      Error in `update()`:
+      ! Please supply at least one parameter object.
 
 # printing
 

--- a/tests/testthat/test-grids.R
+++ b/tests/testthat/test-grids.R
@@ -44,6 +44,11 @@ test_that("regular grid", {
     grid_regular(list(mixture(), trees()), levels = 3),
     grid_regular(mixture(), trees(), levels = 3)
   )
+
+  expect_snapshot(
+    error = TRUE,
+    grid_regular(mixture(), trees(), levels = c(2, trees = 4))
+  )
 })
 
 test_that("random grid", {

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -46,6 +46,7 @@ test_that("create from lists of param objects", {
   expect_equal(p_3$id, c("a", "some name"))
 
   expect_snapshot(error = TRUE, parameters(list(a = mtry(), a = penalty())))
+  expect_snapshot(error = TRUE, parameters(list(a = mtry, a = penalty())))
 })
 
 test_that("updating", {
@@ -61,8 +62,10 @@ test_that("updating", {
 
   expect_snapshot(error = TRUE, update(p_1, new_pen))
   expect_snapshot(error = TRUE, update(p_1, penalty = 1:2))
+  expect_snapshot(error = TRUE, update(p_1, not_penalty = 1:2))
   expect_snapshot(error = TRUE, update(p_1, penalty(), mtry = mtry(3:4)))
   expect_error(update(p_1, penalty = NA), NA)
+  expect_snapshot(error = TRUE, update(p_1))
 })
 
 test_that("printing", {


### PR DESCRIPTION
Ref: https://github.com/tidymodels/dials/issues/311

This PR changes `rlang::abort()` to `cli::cli_abort()` in `parameters.R`, `grids.R` and `misc.R`.