### PR TITLE
Switch from `rlang::abort()` in `aaa_ranges.R`, `aaa_unknown.R`, `encode_unit.R`, and `finalize.R`

### DIFF
--- a/R/aaa_ranges.R
+++ b/R/aaa_ranges.R
@@ -51,13 +51,17 @@ range_validate <- function(object,
                            call = caller_env()
                            ) {
   ukn_txt <- if (ukn_ok) {
-    "`Inf` and `unknown()` are acceptable values."
+    c(i = "{.code Inf} and {.code unknown()} are acceptable values.")
   } else {
-    ""
+    NULL
   }
   if (length(range) != 2) {
-    rlang::abort(
-      paste("`range` must have two values: an upper and lower bound.", ukn_txt),
+    cli::cli_abort(
+      c(
+        x = "{.arg range} must have two values: an upper and lower bound.", 
+        i = "{length(range)} value{?s} {?was/were} provided.",
+        ukn_txt
+      ),
       call = call
     )
   }
@@ -68,22 +72,28 @@ range_validate <- function(object,
 
   if (!ukn_ok) {
     if (any(is_unk)) {
-      rlang::abort(
+      cli::cli_abort(
         "Cannot validate ranges when they contains 1+ unknown values.",
         call = call
       )
     }
     if (!any(is_num)) {
-      rlang::abort("`range` should be numeric.", call = call)
+      cli::cli_abort("{.arg range} should be numeric.", call = call)
     }
 
     # TODO check with transform
   } else {
     if (any(is_na[!is_unk])) {
-      rlang::abort("Value ranges must be non-missing.", ukn_txt, call = call)
+      cli::cli_abort(
+        c(x = "Value ranges must be non-missing.", ukn_txt), 
+        call = call
+      )
     }
     if (any(!is_num[!is_unk])) {
-      rlang::abort("Value ranges must be numeric.", ukn_txt, call = call)
+      cli::cli_abort(
+        c("Value ranges must be numeric.", ukn_txt), 
+        call = call
+      )
     }
   }
   range
@@ -104,7 +114,9 @@ range_get <- function(object, original = TRUE) {
 #' @rdname range_validate
 range_set <- function(object, range) {
   if (length(range) != 2) {
-    rlang::abort("`range` should have two elements.")
+    cli::cli_abort(
+      "{.arg range} should have two elements, not {length(range)}."
+    )
   }
   if (inherits(object, "quant_param")) {
     object <-
@@ -117,7 +129,10 @@ range_set <- function(object, range) {
         label = object$label
       )
   } else {
-    rlang::abort("`object` should be a 'quant_param' object")
+    cli::cli_abort(
+      "{.arg object} should be a {.cls quant_param} object, 
+      not {.obj_type_friendly {object}}."
+    )
   }
   object
 }

--- a/R/aaa_unknown.R
+++ b/R/aaa_unknown.R
@@ -86,11 +86,11 @@ check_for_unknowns <- function(x, ..., call = caller_env()) {
     return(invisible(TRUE))
   }
   if (length(x) == 1 && is_unknown(x)) {
-    rlang::abort("Unknowns not allowed.", call = call)
+    cli::cli_abort("Unknowns not allowed.", call = call)
   }
   is_ukn <- map_lgl(x, is_unknown)
   if (any(is_ukn)) {
-    rlang::abort("Unknowns not allowed.", call = call)
+    cli::cli_abort("Unknowns not allowed.", call = call)
   }
   invisible(TRUE)
 }

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -40,7 +40,7 @@
 #'
 #' @inheritParams rlang::args_dots_empty
 #'
-#' @param call The call passed on to [rlang::abort()].
+#' @param call The call passed on to [cli::cli_abort()].
 #'
 #' @return
 #'

--- a/R/encode_unit.R
+++ b/R/encode_unit.R
@@ -20,18 +20,18 @@ encode_unit <- function(x, value, direction, ...) {
 
 #' @export
 encode_unit.default <- function(x, value, direction, ...) {
-  rlang::abort("`x` should be a dials parameter object.")
+  cli::cli_abort("{.arg x} should be a dials parameter object.")
 }
 
 #' @rdname encode_unit
 #' @export
 encode_unit.quant_param <- function(x, value, direction, original = TRUE, ...) {
   if (has_unknowns(x)) {
-    rlang::abort("The parameter object contains unknowns.")
+    cli::cli_abort("The parameter object contains unknowns.")
   }
 
   if (!is.numeric(value) || is.matrix(value)) {
-    rlang::abort("`value` should be a numeric vector.")
+    cli::cli_abort("`value` should be a numeric vector.")
   }
 
   param_rng <- x$range$upper - x$range$lower
@@ -44,7 +44,7 @@ encode_unit.quant_param <- function(x, value, direction, original = TRUE, ...) {
 
     compl <- value[!is.na(value)]
     if (any(compl < 0) | any(compl > 1)) {
-      rlang::abort("Values should be on [0, 1].")
+      cli::cli_abort("Values should be on [0, 1].")
     }
 
     value <- (value * param_rng) + x$range$lower
@@ -67,7 +67,7 @@ encode_unit.quant_param <- function(x, value, direction, original = TRUE, ...) {
 #' @export
 encode_unit.qual_param <- function(x, value, direction, ...) {
   if (has_unknowns(x)) {
-    rlang::abort("The parameter object contains unknowns.")
+    cli::cli_abort("The parameter object contains unknowns.")
   }
 
   ref_vals <- x$values
@@ -77,15 +77,17 @@ encode_unit.qual_param <- function(x, value, direction, ...) {
     # convert to [0, 1]
 
     if (!is.character(value) || is.matrix(value)) {
-      rlang::abort("`value` should be a character vector.")
+      cli::cli_abort("{.arg value} should be a character vector.")
     }
 
     compl <- value[!is.na(value)]
     if (!all(compl %in% ref_vals)) {
       bad_vals <- compl[!(compl %in% ref_vals)]
-      rlang::abort(
-        "Some values are not in the reference set of possible values: ",
-        paste0("'", unique(bad_vals), "'", collapse = ", ")
+      bad_vals <- unique(bad_vals)
+
+      cli::cli_abort(
+        "Some values are not in the reference set of possible values: 
+          {.val bad_vals}}."
       )
     }
     fac <- factor(value, levels = ref_vals)
@@ -95,11 +97,11 @@ encode_unit.qual_param <- function(x, value, direction, ...) {
 
     compl <- value[!is.na(value)]
     if (any(compl < 0) | any(compl > 1)) {
-      rlang::abort("Values should be on [0, 1].")
+      cli::cli_abort("Values should be on [0, 1].")
     }
 
     if (!is.numeric(value) || is.matrix(value)) {
-      rlang::abort("`value` should be a numeric vector.")
+      cli::cli_abort("{.arg value} should be a numeric vector.")
     }
 
     ind <- cut(value, breaks = seq(0, 1, length.out = num_lvl + 1), include.lowest = TRUE)

--- a/R/encode_unit.R
+++ b/R/encode_unit.R
@@ -31,7 +31,7 @@ encode_unit.quant_param <- function(x, value, direction, original = TRUE, ...) {
   }
 
   if (!is.numeric(value) || is.matrix(value)) {
-    cli::cli_abort("`value` should be a numeric vector.")
+    cli::cli_abort("{.arg value} should be a numeric vector.")
   }
 
   param_rng <- x$range$upper - x$range$lower

--- a/R/finalize.R
+++ b/R/finalize.R
@@ -142,8 +142,9 @@ finalize.default <- function(object, x, force = TRUE, ...) {
   if (all(is.na(object))) {
     return(object)
   } else {
-    cls <- paste0("'", class(x), "'", collapse = ", ")
-    rlang::abort(paste0("Cannot finalize an object with class(es): ", cls))
+    cli::cli_abort(
+      "Cannot finalize an object with class{?es}: {.cls {class(x)}}."
+    )
   }
   object
 }
@@ -161,7 +162,9 @@ get_p <- function(object, x, log_vals = FALSE, ...) {
 
   x_dims <- dim(x)
   if (is.null(x_dims)) {
-    rlang::abort("Cannot determine number of columns. Is `x` a 2D data object?")
+    cli::cli_abort(
+      "Cannot determine number of columns. Is {.arg x} a 2D data object?"
+    )
   }
 
   if (log_vals) {
@@ -195,7 +198,9 @@ get_n_frac <- function(object, x, log_vals = FALSE, frac = 1/3, ...) {
 
   x_dims <- dim(x)
   if (is.null(x_dims)) {
-    rlang::abort("Cannot determine number of columns. Is `x` a 2D data object?")
+    cli::cli_abort(
+      "Cannot determine number of columns. Is {.arg x} a 2D data object?"
+    )
   }
 
   n_frac <- floor(x_dims[1] * frac)
@@ -221,7 +226,9 @@ get_n_frac_range <- function(object, x, log_vals = FALSE, frac = c(1/10, 5/10), 
 
   x_dims <- dim(x)
   if (is.null(x_dims)) {
-    rlang::abort("Cannot determine number of columns. Is `x` a 2D data object?")
+    cli::cli_abort(
+      "Cannot determine number of columns. Is {.arg x} a 2D data object?"
+    )
   }
 
   n_frac <- sort(floor(x_dims[1] * frac))
@@ -252,7 +259,9 @@ get_rbf_range <- function(object, x, seed = sample.int(10^5, 1), ...) {
   suppressPackageStartupMessages(requireNamespace("kernlab", quietly = TRUE))
   x_mat <- as.matrix(x)
   if (!is.numeric(x_mat)) {
-    rlang::abort("The matrix version of the initialization data is not numeric.")
+    cli::cli_abort(
+      "The matrix version of the initialization data is not numeric."
+    )
   }
   with_seed(seed, rng <- kernlab::sigest(x_mat, ...)[-2])
   rng <- log10(rng)
@@ -269,7 +278,9 @@ get_batch_sizes <- function(object, x, frac = c(1/10, 1/3), ...) {
 
   x_dims <- dim(x)
   if (is.null(x_dims)) {
-    rlang::abort("Cannot determine number of columns. Is `x` a 2D data object?")
+    cli::cli_abort(
+      "Cannot determine number of columns. Is {.arg x} a 2D data object?"
+    )
   }
 
   n_frac <- sort(floor(x_dims[1] * frac))

--- a/man/new-param.Rd
+++ b/man/new-param.Rd
@@ -66,7 +66,7 @@ values of a parameter (such as the \code{range}).}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
-\item{call}{The call passed on to \code{\link[rlang:abort]{rlang::abort()}}.}
+\item{call}{The call passed on to \code{\link[cli:cli_abort]{cli::cli_abort()}}.}
 }
 \value{
 An object of class \code{"param"} with the primary class being either

--- a/man/range_validate.Rd
+++ b/man/range_validate.Rd
@@ -23,7 +23,7 @@ an acceptable value.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
-\item{call}{The call passed on to \code{\link[rlang:abort]{rlang::abort()}}.}
+\item{call}{The call passed on to \code{\link[cli:cli_abort]{cli::cli_abort()}}.}
 
 \item{original}{A single logical. Should the range values be in the natural
 units (\code{TRUE}) or in the transformed space (\code{FALSE}, if applicable)?}

--- a/man/value_validate.Rd
+++ b/man/value_validate.Rd
@@ -30,7 +30,7 @@ consistent with the parameter object's definition.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
-\item{call}{The call passed on to \code{\link[rlang:abort]{rlang::abort()}}.}
+\item{call}{The call passed on to \code{\link[cli:cli_abort]{cli::cli_abort()}}.}
 
 \item{n}{An integer for the (maximum) number of values to return. In some
 cases where a sequence is requested, the result might have less than \code{n}

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -36,7 +36,8 @@
       new_quant_param("double", range = c(1, NA), inclusive = c(TRUE, TRUE))
     Condition
       Error:
-      ! Value ranges must be non-missing.
+      x Value ranges must be non-missing.
+      i `Inf` and `unknown()` are acceptable values.
 
 ---
 
@@ -60,7 +61,8 @@
       new_quant_param("double", range = c(1, NA), inclusive = c(TRUE, TRUE))
     Condition
       Error:
-      ! Value ranges must be non-missing.
+      x Value ranges must be non-missing.
+      i `Inf` and `unknown()` are acceptable values.
 
 ---
 
@@ -109,7 +111,9 @@
       range_validate(mtry(), range = 1)
     Condition
       Error:
-      ! `range` must have two values: an upper and lower bound. `Inf` and `unknown()` are acceptable values.
+      x `range` must have two values: an upper and lower bound.
+      i 1 value was provided.
+      i `Inf` and `unknown()` are acceptable values.
 
 ---
 
@@ -117,7 +121,8 @@
       range_validate(mtry(), range = c(1, NA))
     Condition
       Error:
-      ! Value ranges must be non-missing.
+      x Value ranges must be non-missing.
+      i `Inf` and `unknown()` are acceptable values.
 
 ---
 
@@ -134,6 +139,7 @@
     Condition
       Error:
       ! Value ranges must be numeric.
+      i `Inf` and `unknown()` are acceptable values.
 
 # printing
 


### PR DESCRIPTION
Ref: #311 

This PR switches from `rlang::abort()` in `aaa_ranges.R`, `aaa_unknown.R`, `encode_unit.R`, and `finalize.R`