### PR TITLE
No more `cat()` in printing methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dials (development version)
 
+* All messages, warnings and errors has been translated to use {cli} package (#311). 
+
 # dials 1.3.0
 
 ## Improvements

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -262,9 +262,9 @@ print_transformer <- function(x) {
 #' @export
 print.qual_param <- function(x, ...) {
   if (!is.null(x$label)) {
-    cat(x$label, " (qualitative)\n")
+    cli::cli_text("{x$label} (qualitative)")
   } else {
-    cat("Qualitative Parameter\n")
+    cli::cli_text("Qualitative Parameter")
   }
   n_values <- length(x$values)
   cli::cli_text("{n_values} possible value{?s} include:")
@@ -273,14 +273,7 @@ print.qual_param <- function(x, ...) {
   } else {
     lvls <- x$values
   }
-  cat(
-    glue_collapse(
-      lvls,
-      sep = ", ",
-      last = " and ",
-      width = options()$width
-    ),
-    "\n"
-  )
+
+  cli::cli_text("{lvls}")
   invisible(x)
 }

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -225,9 +225,9 @@ print.quant_param <- function(x, digits = 3, ...) {
 
 cat_quant_param_header <- function(x) {
   if (!is.null(x$label)) {
-    cat_line(x$label, " (quantitative)")
+    cli::cli_text("{x$label} (quantitative)")
   } else {
-    cat_line("Quantitative Parameter")
+    cli::cli_text("Quantitative Parameter")
   }
 }
 
@@ -237,7 +237,7 @@ cat_quant_param_range <- function(x) {
   range <- map_chr(x$range, format_range_val)
   range <- format_range(x, range)
 
-  cat_line(label, range)
+  cli::cli_text("{label}{range}")
 }
 
 cat_quant_param_values <- function(x) {
@@ -249,17 +249,14 @@ cat_quant_param_values <- function(x) {
 
   n_values <- length(values)
 
-  cat_line(glue("Values: {n_values}"))
+  cli::cli_text("Values: {n_values}")
 }
 
 print_transformer <- function(x) {
   if (!is.null(x$trans)) {
-    print(eval(x$trans))
+    text <- utils::capture.output(eval(x$trans))
+    cli::cli_text(text)
   }
-}
-
-cat_line <- function(...) {
-  cat(paste0(..., "\n", collapse = ""))
 }
 
 #' @export

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -255,7 +255,7 @@ print_quant_param_values <- function(x) {
 print_quant_param_transformer <- function(x) {
   if (!is.null(x$trans)) {
     text <- utils::capture.output(eval(x$trans))
-    cli::cli_text(text)
+    cli::cli_verbatim(text)
   }
 }
 

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -216,14 +216,14 @@ new_qual_param <- function(type = c("character", "logical"),
 
 #' @export
 print.quant_param <- function(x, digits = 3, ...) {
-  cat_quant_param_header(x)
-  print_transformer(x)
-  cat_quant_param_range(x)
-  cat_quant_param_values(x)
+  print_quant_param_header(x)
+  print_quant_param_transformer(x)
+  print_quant_param_range(x)
+  print_quant_param_values(x)
   invisible(x)
 }
 
-cat_quant_param_header <- function(x) {
+print_quant_param_header <- function(x) {
   if (!is.null(x$label)) {
     cli::cli_text("{x$label} (quantitative)")
   } else {
@@ -231,7 +231,7 @@ cat_quant_param_header <- function(x) {
   }
 }
 
-cat_quant_param_range <- function(x) {
+print_quant_param_range <- function(x) {
   label <- format_range_label(x, "Range")
 
   range <- map_chr(x$range, format_range_val)
@@ -240,7 +240,7 @@ cat_quant_param_range <- function(x) {
   cli::cli_text("{label}{range}")
 }
 
-cat_quant_param_values <- function(x) {
+print_quant_param_values <- function(x) {
   values <- x$values
 
   if (is.null(values)) {
@@ -252,7 +252,7 @@ cat_quant_param_values <- function(x) {
   cli::cli_text("Values: {n_values}")
 }
 
-print_transformer <- function(x) {
+print_quant_param_transformer <- function(x) {
   if (!is.null(x$trans)) {
     text <- utils::capture.output(eval(x$trans))
     cli::cli_text(text)
@@ -266,6 +266,7 @@ print.qual_param <- function(x, ...) {
   } else {
     cli::cli_text("Qualitative Parameter")
   }
+
   n_values <- length(x$values)
   cli::cli_text("{n_values} possible value{?s} include:")
   if (x$type == "character") {
@@ -273,7 +274,7 @@ print.qual_param <- function(x, ...) {
   } else {
     lvls <- x$values
   }
-
   cli::cli_text("{lvls}")
+
   invisible(x)
 }

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -191,7 +191,7 @@ print.parameters <- function(x, ...) {
      needs_param <- print_x$identifier[null_obj]
     cli::cli_par()
     cli::cli_text(
-      "The parameter{?s} {.var {needs_param}} {?needs a/need} {.var param}
+      "The parameter{?s} {.var {needs_param}} {?needs a/need} {.cls param}
       {?object/objects}."
     )
     cli::cli_end()

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -164,7 +164,9 @@ unk_check <- function(x) {
 print.parameters <- function(x, ...) {
   x <- tibble::as_tibble(x)
 
-  cat("Collection of", nrow(x), "parameters for tuning\n\n")
+  cli::cli_par()
+  cli::cli_text("Collection of {nrow(x)} parameters for tuning")
+  cli::cli_end()
 
   print_x <- x %>% dplyr::select(identifier = id, type = name, object)
   print_x$object <-
@@ -176,35 +178,21 @@ print.parameters <- function(x, ...) {
         pillar::type_sum(.x)
       }
     )
-
-  print.data.frame(print_x, row.names = FALSE)
-  cat("\n")
+ 
+  cli::cli_par()
+  cli::cli_verbatim(
+    utils::capture.output(print.data.frame(print_x, row.names = FALSE))
+  )
+  cli::cli_end()
 
   null_obj <- map_lgl(x$object, ~ all(is.na(.x)))
 
   if (any(null_obj)) {
-    needs_param <- print_x$identifier[null_obj]
+     needs_param <- print_x$identifier[null_obj]
 
-    last_sep <- if (length(needs_param) == 2) {
-      "` and `"
-    } else {
-      "`, and `"
-    }
-
-    param_descs <- paste0(
-      "`",
-      glue::glue_collapse(print_x$identifier[null_obj], sep = "`, `", last = last_sep),
-      "`"
-    )
-
-    plural <- length(needs_param) != 1
-
-    rlang::inform(
-      glue::glue(
-        "The parameter{if (plural) 's' else ''} {param_descs} ",
-        "{if (plural) {'need `param` objects'} else {'needs a `param` object'}}. ",
-        "\nSee `vignette('dials')` to learn more."
-      )
+    cli::cli_text(
+      "The parameter{?s} {.var {needs_param}} {?needs a/need} {.var param} 
+      {?object/objects}. See {.code vignette('dials')} to learn more."
     )
   }
 
@@ -220,23 +208,29 @@ print.parameters <- function(x, ...) {
     # There's a more elegant way to do this, I'm sure:
     mod_obj <- as_tibble(other_obj) %>% dplyr::filter(source == "model_spec" & not_final)
     if (nrow(mod_obj) > 0) {
-      cat("Model parameters needing finalization:\n")
-      cat(mod_obj$note, sep = "")
-      cat("\n")
+      cli::cli_par()
+      cli::cli_text("Model parameters needing finalization:")
+      cli::cli_text("{mod_obj$note}")
+      cli::cli_end()
     }
     rec_obj <- as_tibble(other_obj) %>% dplyr::filter(source == "recipe" & not_final)
     if (nrow(rec_obj) > 0) {
-      cat("Recipe parameters needing finalization:\n")
-      cat(rec_obj$note, sep = "")
-      cat("\n")
+      cli::cli_par()
+      cli::cli_text("Recipe parameters needing finalization:")
+      cli::cli_text("{rec_obj$note}")
+      cli::cli_end()
     }
     lst_obj <- as_tibble(other_obj) %>% dplyr::filter(source == "list" & not_final)
     if (nrow(lst_obj) > 0) {
-      cat("Parameters needing finalization:\n")
-      cat(lst_obj$note, sep = "")
-      cat("\n")
+      cli::cli_par()
+      cli::cli_text("Parameters needing finalization:")
+      cli::cli_text("{lst_obj$note}")
+      cli::cli_end()
     }
-    cat("See `?dials::finalize` or `?dials::update.parameters` for more information.\n\n")
+    cli::cli_text(
+      "See {.help dials::finalize} or {.help dials::update.parameters} for 
+      more information."
+    )
   }
 
   invisible(x)

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -189,11 +189,12 @@ print.parameters <- function(x, ...) {
 
   if (any(null_obj)) {
      needs_param <- print_x$identifier[null_obj]
-
+    cli::cli_par()
     cli::cli_text(
-      "The parameter{?s} {.var {needs_param}} {?needs a/need} {.var param} 
-      {?object/objects}. See {.code vignette('dials')} to learn more."
+      "The parameter{?s} {.var {needs_param}} {?needs a/need} {.var param}
+      {?object/objects}."
     )
+    cli::cli_end()
   }
 
   other_obj <-

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -145,7 +145,7 @@
 
     Code
       mtry()
-    Output
+    Message
       # Randomly Selected Predictors (quantitative)
       Range: [1, ?]
 
@@ -164,7 +164,7 @@
 
     Code
       value_set(cost_complexity(), log10(c(0.09, 1e-04)))
-    Output
+    Message
       Cost-Complexity Parameter (quantitative)
       Transformer: log-10 [1e-100, Inf]
       Range (transformed scale): [-10, -1]

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -153,12 +153,11 @@
 
     Code
       surv_dist()
-    Output
-      Distribution  (qualitative)
     Message
+      Distribution (qualitative)
       6 possible values include:
-    Output
-      'weibull', 'exponential', 'gaussian', 'logistic', 'lognormal' and 'loglogistic' 
+      'weibull', 'exponential', 'gaussian', 'logistic', 'lognormal', and
+      'loglogistic'
 
 ---
 

--- a/tests/testthat/_snaps/parameters.md
+++ b/tests/testthat/_snaps/parameters.md
@@ -100,7 +100,7 @@
        identifier   type  object
            trials trials missing
       
-      The parameter `trials` needs a `param` object.
+      The parameter `trials` needs a <param> object.
       
 
 ---
@@ -114,7 +114,7 @@
            trials trials missing
             rules  rules missing
       
-      The parameters `trials` and `rules` need `param` objects.
+      The parameters `trials` and `rules` need <param> objects.
       
 
 ---
@@ -129,7 +129,7 @@
             rules  rules missing
             costs  costs missing
       
-      The parameters `trials`, `rules`, and `costs` need `param` objects.
+      The parameters `trials`, `rules`, and `costs` need <param> objects.
       
 
 # parameters.default

--- a/tests/testthat/_snaps/parameters.md
+++ b/tests/testthat/_snaps/parameters.md
@@ -78,7 +78,7 @@
 
     Code
       parameters(list(mtry(), penalty()))
-    Output
+    Message
       Collection of 2 parameters for tuning
       
        identifier    type    object
@@ -86,45 +86,42 @@
           penalty penalty nparam[+]
       
       Parameters needing finalization:
-         # Randomly Selected Predictors ('mtry')
+      # Randomly Selected Predictors ('mtry')
       
-      See `?dials::finalize` or `?dials::update.parameters` for more information.
-      
+      See `?dials::finalize()` or `?dials::update.parameters()` for more information.
 
 ---
 
     Code
       ex_params[1, ] %>% structure(class = c("parameters", class(.)))
-    Output
+    Message
       Collection of 1 parameters for tuning
       
        identifier   type  object
            trials trials missing
       
-    Message
-      The parameter `trials` needs a `param` object. 
-      See `vignette('dials')` to learn more.
+      The parameter `trials` needs a `param` object. See `vignette('dials')` to learn
+      more.
 
 ---
 
     Code
       ex_params[1:2, ] %>% structure(class = c("parameters", class(.)))
-    Output
+    Message
       Collection of 2 parameters for tuning
       
        identifier   type  object
            trials trials missing
             rules  rules missing
       
-    Message
-      The parameters `trials` and `rules` need `param` objects. 
-      See `vignette('dials')` to learn more.
+      The parameters `trials` and `rules` need `param` objects. See
+      `vignette('dials')` to learn more.
 
 ---
 
     Code
       ex_params[1:3, ] %>% structure(class = c("parameters", class(.)))
-    Output
+    Message
       Collection of 3 parameters for tuning
       
        identifier   type  object
@@ -132,9 +129,8 @@
             rules  rules missing
             costs  costs missing
       
-    Message
-      The parameters `trials`, `rules`, and `costs` need `param` objects. 
-      See `vignette('dials')` to learn more.
+      The parameters `trials`, `rules`, and `costs` need `param` objects. See
+      `vignette('dials')` to learn more.
 
 # parameters.default
 

--- a/tests/testthat/_snaps/parameters.md
+++ b/tests/testthat/_snaps/parameters.md
@@ -100,8 +100,8 @@
        identifier   type  object
            trials trials missing
       
-      The parameter `trials` needs a `param` object. See `vignette('dials')` to learn
-      more.
+      The parameter `trials` needs a `param` object.
+      
 
 ---
 
@@ -114,8 +114,8 @@
            trials trials missing
             rules  rules missing
       
-      The parameters `trials` and `rules` need `param` objects. See
-      `vignette('dials')` to learn more.
+      The parameters `trials` and `rules` need `param` objects.
+      
 
 ---
 
@@ -129,8 +129,8 @@
             rules  rules missing
             costs  costs missing
       
-      The parameters `trials`, `rules`, and `costs` need `param` objects. See
-      `vignette('dials')` to learn more.
+      The parameters `trials`, `rules`, and `costs` need `param` objects.
+      
 
 # parameters.default
 


### PR DESCRIPTION
ref: #311

This should end our cli conversion and close #311. I left a few comments to explain what I did