### PR TITLE
Update usage of `expect_error()`

### DIFF
--- a/tests/testthat/test-grids.R
+++ b/tests/testthat/test-grids.R
@@ -1,11 +1,5 @@
 
 test_that("regular grid", {
-  expect_error(
-    grid_regular(mtcars)
-  )
-  expect_error(
-    grid_regular()
-  )
   expect_snapshot(
     error = TRUE,
     grid_regular(mixture(), trees(), levels = 1:4)
@@ -52,12 +46,6 @@ test_that("regular grid", {
 })
 
 test_that("random grid", {
-  expect_error(
-    grid_random(mtcars)
-  )
-  expect_error(
-    grid_random()
-  )
   expect_equal(
     nrow(grid_random(mixture(), trees(), size = 2)),
     2
@@ -75,7 +63,7 @@ test_that("wrong argument name", {
   skip_if_below_r_version("3.6")
   p <- parameters(penalty(), mixture())
   set.seed(1)
-  
+
   expect_snapshot(grid_space_filling(p, levels = 5, type = "latin_hypercube"))
   expect_snapshot(grid_space_filling(p, levels = 5, type = "max_entropy"))
   expect_snapshot(grid_random(p, levels = 5))
@@ -102,6 +90,6 @@ test_that("filter arg yields same results", {
 test_that("new param grid from conventional data frame", {
   x <- data.frame(num_comp = 1:3)
 
-  expect_error(y <- dials:::new_param_grid(x), regexp = NA)
+  expect_no_condition(y <- dials:::new_param_grid(x))
   expect_true(tibble::is_tibble(y))
 })

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -21,26 +21,28 @@ test_that("parameters_const() input checks", {
 })
 
 test_that("create from param objects", {
-  expect_error(p_1 <- parameters(mtry(), penalty()), NA)
+  expect_no_condition(p_1 <- parameters(mtry(), penalty()))
   expect_s3_class_parameters(p_1)
   expect_equal(p_1 %>% nrow(), 2)
 
-  expect_error(p_2 <- parameters(penalty()), NA)
+  expect_no_condition(p_2 <- parameters(penalty()))
   expect_s3_class_parameters(p_2)
   expect_equal(p_2 %>% nrow(), 1)
 })
 
 
 test_that("create from lists of param objects", {
-  expect_error(p_1 <- parameters(list(mtry(), penalty())), NA)
+  expect_no_condition(p_1 <- parameters(list(mtry(), penalty())))
   expect_s3_class_parameters(p_1)
   expect_equal(p_1 %>% nrow(), 2)
 
-  expect_error(p_2 <- parameters(list(penalty())), NA)
+  expect_no_condition(p_2 <- parameters(list(penalty())))
   expect_s3_class_parameters(p_2)
   expect_equal(p_2 %>% nrow(), 1)
 
-  expect_error(p_3 <- parameters(list(a = mtry(), "some name" = penalty())), NA)
+  expect_no_condition(
+    p_3 <- parameters(list(a = mtry(), "some name" = penalty()))
+  )
   expect_s3_class_parameters(p_3)
   expect_equal(p_3 %>% nrow(), 2)
   expect_equal(p_3$id, c("a", "some name"))
@@ -64,7 +66,7 @@ test_that("updating", {
   expect_snapshot(error = TRUE, update(p_1, penalty = 1:2))
   expect_snapshot(error = TRUE, update(p_1, not_penalty = 1:2))
   expect_snapshot(error = TRUE, update(p_1, penalty(), mtry = mtry(3:4)))
-  expect_error(update(p_1, penalty = NA), NA)
+  expect_no_condition(update(p_1, penalty = NA))
   expect_snapshot(error = TRUE, update(p_1))
 })
 

--- a/tests/testthat/test-space_filling.R
+++ b/tests/testthat/test-space_filling.R
@@ -31,23 +31,10 @@ test_that("max entropy designs", {
   )
   expect_equal(ncol(grid_3), 1L)
 
-  expect_error(
-    grid_max_entropy(
-      cost,
-      size = 11,
-      original = FALSE
-    )
-  )
   expect_snapshot(
     error = TRUE,
     grid_max_entropy(
       mtry(),
-      size = 11,
-      original = FALSE
-    )
-  )
-  expect_error(
-    grid_max_entropy(
       size = 11,
       original = FALSE
     )
@@ -92,23 +79,10 @@ test_that("latin square designs", {
     20
   )
 
-  expect_error(
-    grid_latin_hypercube(
-      cost,
-      size = 11,
-      original = FALSE
-    )
-  )
   expect_snapshot(
     error = TRUE,
     grid_latin_hypercube(
       mtry(),
-      size = 11,
-      original = FALSE
-    )
-  )
-  expect_error(
-    grid_latin_hypercube(
       size = 11,
       original = FALSE
     )


### PR DESCRIPTION
- `expect_error({expr}, NA)` -> `expect_no_condition()`
- removing tests on an error being thrown from base-R by `UseMethod()`, e.g.,

```
>     grid_max_entropy(
+       size = 11,
+       original = FALSE
+     )
Error in UseMethod("grid_max_entropy") : 
  no applicable method for 'grid_max_entropy' applied to an object of class "c('double', 'numeric')"
```