### PR TITLE
use a random design for size = 1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
 
 * All messages, warnings and errors has been translated to use {cli} package (#311). 
 
+* For space-filling designs for $p$ parameters, there is a higher likelihood of finding a space-filling design for `1 < size <= p`. Also, single-point designs now default to a random grid. 
+
 # dials 1.3.0
 
 ## Improvements

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 
 * All messages, warnings and errors has been translated to use {cli} package (#311). 
 
-* For space-filling designs for $p$ parameters, there is a higher likelihood of finding a space-filling design for `1 < size <= p`. Also, single-point designs now default to a random grid. 
+* For space-filling designs for $p$ parameters, there is a higher likelihood of finding a space-filling design for `1 < size <= p`. Also, single-point designs now default to a random grid (#363).
 
 # dials 1.3.0
 

--- a/R/space_filling.R
+++ b/R/space_filling.R
@@ -15,8 +15,7 @@
 #' `"audze_eglais"`, `"max_min_l1"`, `"max_min_l2"`, `"uniform"`,
 #' `"max_entropy"`, or `"latin_hypercube"`. A value of `"any"` will choose the
 #' first design available (in the order listed above, excluding
-#' `"latin_hypercube"`). If the design is extremely small, the function may
-#' change the type to `"latin_hypercube"` (with a warning).
+#' `"latin_hypercube"`). For a single-point design, a random grid is created.
 #' @param variogram_range A numeric value greater than zero. Larger values
 #'  reduce the likelihood of empty regions in the parameter space. Only used
 #'  for `type = "max_entropy"`.
@@ -193,10 +192,9 @@ make_sfd <- function(...,
   params <- map(param_quos, eval_tidy)
   p <- length(params)
 
-  if (size < p | size == 1) {
-    cli::cli_warn("Due to the small size of the grid, a Latin hypercube \\
-                  design will be used.")
-    type <- "latin_hypercube"
+  if (size == 1) {
+    res <- dials::grid_random(params, size = size)
+    return(res)
   }
 
   if (type %in% c("any", "audze_eglais", "max_min_l1", "max_min_l2", "uniform")) {

--- a/R/space_filling.R
+++ b/R/space_filling.R
@@ -193,7 +193,7 @@ make_sfd <- function(...,
   p <- length(params)
 
   if (size == 1) {
-    res <- dials::grid_random(params, size = size)
+    res <- grid_random(params, size = size)
     return(res)
   }
 

--- a/man/grid_space_filling.Rd
+++ b/man/grid_space_filling.Rd
@@ -54,8 +54,7 @@ generated from this size, the smaller, unique set is returned.}
 \code{"audze_eglais"}, \code{"max_min_l1"}, \code{"max_min_l2"}, \code{"uniform"},
 \code{"max_entropy"}, or \code{"latin_hypercube"}. A value of \code{"any"} will choose the
 first design available (in the order listed above, excluding
-\code{"latin_hypercube"}). If the design is extremely small, the function may
-change the type to \code{"latin_hypercube"} (with a warning).}
+\code{"latin_hypercube"}). For a single-point design, a random grid is created.}
 
 \item{original}{A logical: should the parameters be in the original units or
 in the transformed space (if any)?}

--- a/tests/testthat/_snaps/space_filling.md
+++ b/tests/testthat/_snaps/space_filling.md
@@ -55,11 +55,3 @@
       `levels` is not an argument to `grid_space_filling()`.
       i Did you mean `size`?
 
-# very small designs
-
-    Due to the small size of the grid, a Latin hypercube design will be used.
-
----
-
-    Due to the small size of the grid, a Latin hypercube design will be used.
-

--- a/tests/testthat/test-space_filling.R
+++ b/tests/testthat/test-space_filling.R
@@ -285,19 +285,11 @@ test_that("S3 methods for space-filling", {
 
 })
 
-test_that("very small designs", {
-
-  expect_snapshot_warning({
-    set.seed(1)
-    small_1 <- grid_space_filling(parameters(neighbors()), size = 1)
+test_that("1-point grid", {
+   expect_silent({
+     set.seed(1)
+     grid <- grid_space_filling(parameters(neighbors()), size = 1)
   })
-  expect_equal(dim(small_1), c(1L, 1L))
-
-  expect_snapshot_warning({
-    set.seed(1)
-    small_2 <- grid_space_filling(parameters(neighbors(), mixture(), penalty()),
-                                  size = 2)
-  })
-  expect_equal(dim(small_2), c(2L, 3L))
-
+  expect_equal(nrow(grid), 1L)
 })
+


### PR DESCRIPTION
Fixes for tidymodels/tune#962

This will stop a lot of irrelevant warnings for iterative search methods. 