### PR TITLE
Error instead of warn with wrong argument capturing the size of the grid

### DIFF
--- a/R/grids.R
+++ b/R/grids.R
@@ -49,11 +49,11 @@
 grid_regular <- function(x, ..., levels = 3, original = TRUE, filter = NULL) {
   dots <- list(...)
   if (any(names(dots) == "size")) {
-    cli::cli_warn(
-     c(
-      "{.arg size} is not an argument to {.fn grid_regular}.",
-      i = "Did you mean {.arg levels}?"
-     )
+    cli::cli_abort(
+      c(
+        "{.arg size} is not an argument to {.fn grid_regular}.",
+        i = "Did you mean {.arg levels}?"
+      )
     )
   }
   UseMethod("grid_regular")
@@ -172,9 +172,11 @@ make_regular_grid <- function(...,
 grid_random <- function(x, ..., size = 5, original = TRUE, filter = NULL) {
   dots <- list(...)
   if (any(names(dots) == "levels")) {
-    cli::cli_warn(c(
-      "{.arg levels} is not an argument to {.fn grid_random}.",
-      i = "Did you mean {.arg size}?")
+    cli::cli_abort(
+      c(
+        "{.arg levels} is not an argument to {.fn grid_random}.",
+        i = "Did you mean {.arg size}?"
+      )
     )
   }
   UseMethod("grid_random")

--- a/R/space_filling.R
+++ b/R/space_filling.R
@@ -91,9 +91,11 @@
 grid_space_filling <- function(x, ..., size = 5, type = "any", original = TRUE) {
   dots <- list(...)
   if (any(names(dots) == "levels")) {
-    cli::cli_warn(c(
-      "{.arg levels} is not an argument to {.fn grid_space_filling}.",
-      i = "Did you mean {.arg size}?")
+    cli::cli_abort(
+      c(
+        "{.arg levels} is not an argument to {.fn grid_space_filling}.",
+        i = "Did you mean {.arg size}?"
+      )
     )
   }
   UseMethod("grid_space_filling")
@@ -281,9 +283,11 @@ grid_max_entropy <- function(x,
 
   dots <- list(...)
   if (any(names(dots) == "levels")) {
-    cli::cli_warn(c(
-      "{.arg levels} is not an argument to {.fn grid_max_entropy}.",
-      i = "Did you mean {.arg size}?")
+    cli::cli_abort(
+      c(
+        "{.arg levels} is not an argument to {.fn grid_max_entropy}.",
+        i = "Did you mean {.arg size}?"
+      )
     )
   }
   UseMethod("grid_max_entropy")
@@ -411,9 +415,11 @@ grid_latin_hypercube <- function(x, ..., size = 3, original = TRUE) {
 
   dots <- list(...)
   if (any(names(dots) == "levels")) {
-    cli::cli_warn(c(
-      "{.arg levels} is not an argument to {.fn grid_latin_hypercube}.",
-      i = "Did you mean {.arg size}?")
+    cli::cli_abort(
+      c(
+        "{.arg levels} is not an argument to {.fn grid_latin_hypercube}.",
+        i = "Did you mean {.arg size}?"
+      )
     )
   }
   UseMethod("grid_latin_hypercube")

--- a/tests/testthat/_snaps/grids.md
+++ b/tests/testthat/_snaps/grids.md
@@ -11,11 +11,9 @@
     Code
       grid_regular(mixture(), trees(), size = 3)
     Condition
-      Warning:
-      `size` is not an argument to `grid_regular()`.
+      Error in `grid_regular()`:
+      ! `size` is not an argument to `grid_regular()`.
       i Did you mean `levels`?
-      Error in `parameters()`:
-      ! The objects should all be <param> objects.
 
 ---
 
@@ -30,76 +28,36 @@
     Code
       grid_space_filling(p, levels = 5, type = "latin_hypercube")
     Condition
-      Warning:
-      `levels` is not an argument to `grid_space_filling()`.
+      Error in `grid_space_filling()`:
+      ! `levels` is not an argument to `grid_space_filling()`.
       i Did you mean `size`?
-    Output
-      # A tibble: 5 x 2
-              penalty mixture
-                <dbl>   <dbl>
-      1 0.00563         0.367
-      2 0.0689          0.754
-      3 0.0000374       0.841
-      4 0.00000000349   0.440
-      5 0.0000000402    0.198
 
 ---
 
     Code
       grid_space_filling(p, levels = 5, type = "max_entropy")
     Condition
-      Warning:
-      `levels` is not an argument to `grid_space_filling()`.
+      Error in `grid_space_filling()`:
+      ! `levels` is not an argument to `grid_space_filling()`.
       i Did you mean `size`?
-    Output
-      # A tibble: 5 x 2
-         penalty mixture
-           <dbl>   <dbl>
-      1 1.37e- 1   0.925
-      2 5.80e- 1   0.237
-      3 1.31e- 5   0.526
-      4 3.77e-10   0.946
-      5 2.56e- 8   0.108
 
 ---
 
     Code
       grid_random(p, levels = 5)
     Condition
-      Warning:
-      `levels` is not an argument to `grid_random()`.
+      Error in `grid_random()`:
+      ! `levels` is not an argument to `grid_random()`.
       i Did you mean `size`?
-    Output
-      # A tibble: 5 x 2
-              penalty mixture
-                <dbl>   <dbl>
-      1 0.00148         0.499
-      2 0.982           0.858
-      3 0.00000201      0.850
-      4 0.00000000125   0.493
-      5 0.0000864       0.968
 
 ---
 
     Code
       grid_regular(p, size = 5)
     Condition
-      Warning:
-      `size` is not an argument to `grid_regular()`.
+      Error in `grid_regular()`:
+      ! `size` is not an argument to `grid_regular()`.
       i Did you mean `levels`?
-    Output
-      # A tibble: 9 x 2
-             penalty mixture
-               <dbl>   <dbl>
-      1 0.0000000001     0  
-      2 0.00001          0  
-      3 1                0  
-      4 0.0000000001     0.5
-      5 0.00001          0.5
-      6 1                0.5
-      7 0.0000000001     1  
-      8 0.00001          1  
-      9 1                1  
 
 # new param grid from conventional data frame
 

--- a/tests/testthat/_snaps/space_filling.md
+++ b/tests/testthat/_snaps/space_filling.md
@@ -27,11 +27,9 @@
     Code
       grid_max_entropy(mixture(), levels = 11)
     Condition
-      Warning:
-      `levels` is not an argument to `grid_max_entropy()`.
+      Error in `grid_max_entropy()`:
+      ! `levels` is not an argument to `grid_max_entropy()`.
       i Did you mean `size`?
-      Error in `parameters()`:
-      ! The objects should all be <param> objects.
 
 # `grid_latin_hypercube()` is deprecated
 
@@ -62,18 +60,16 @@
     Code
       grid_latin_hypercube(mixture(), levels = 11)
     Condition
-      Warning:
-      `levels` is not an argument to `grid_latin_hypercube()`.
+      Error in `grid_latin_hypercube()`:
+      ! `levels` is not an argument to `grid_latin_hypercube()`.
       i Did you mean `size`?
-      Error in `parameters()`:
-      ! The objects should all be <param> objects.
 
 # S3 methods for space-filling
 
     Code
-      des <- grid_space_filling(prm, levels = size, type = "uniform")
+      grid_space_filling(prm, levels = size, type = "uniform")
     Condition
-      Warning:
-      `levels` is not an argument to `grid_space_filling()`.
+      Error in `grid_space_filling()`:
+      ! `levels` is not an argument to `grid_space_filling()`.
       i Did you mean `size`?
 

--- a/tests/testthat/test-grids.R
+++ b/tests/testthat/test-grids.R
@@ -72,10 +72,14 @@ test_that("wrong argument name", {
   p <- parameters(penalty(), mixture())
   set.seed(1)
 
-  expect_snapshot(grid_space_filling(p, levels = 5, type = "latin_hypercube"))
-  expect_snapshot(grid_space_filling(p, levels = 5, type = "max_entropy"))
-  expect_snapshot(grid_random(p, levels = 5))
-  expect_snapshot(grid_regular(p, size = 5))
+  expect_snapshot(error = TRUE, {
+    grid_space_filling(p, levels = 5, type = "latin_hypercube")
+  })
+  expect_snapshot(error = TRUE, {
+    grid_space_filling(p, levels = 5, type = "max_entropy")
+  })
+  expect_snapshot(error = TRUE, grid_random(p, levels = 5))
+  expect_snapshot(error = TRUE, grid_regular(p, size = 5))
 })
 
 test_that("filter arg yields same results", {

--- a/tests/testthat/test-space_filling.R
+++ b/tests/testthat/test-space_filling.R
@@ -313,10 +313,9 @@ test_that("S3 methods for space-filling", {
   expect_equal(design_paramset, design_list)
 
   ## also:
-  expect_snapshot(
-    des <- grid_space_filling(prm, levels = size, type = "uniform")
-  )
-
+  expect_snapshot(error = TRUE, {
+    grid_space_filling(prm, levels = size, type = "uniform")
+  })
 })
 
 test_that("1-point grid", {


### PR DESCRIPTION
closes  #364

I went with throwing an error instead of a warning because it seemed sufficiently important to know when your grid wouldn't be the size you expected.