### PR TITLE
Check compatibility of `inclusive` and `range` for integer parameters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,11 @@
 
 * For space-filling designs for $p$ parameters, there is a higher likelihood of finding a space-filling design for `1 < size <= p`. Also, single-point designs now default to a random grid (#363).
 
+## Breaking changes
+
 * The `grid_*()` functions now error instead of warn when provided with the wrong argument to control the grid size. So `grid_space_filling()`, `grid_random()`, `grid_max_entropy()`, and `grid_latin_hypercube()` now error if used with a `levels` argument and `grid_regular()` now errors if used with a `size` argument (#368).
+
+* When constructing integer-valued parameters with a range of two consecutive values the `inclusive` argument needs to be set to `c(TRUE, TRUE)` to leave at least two values to sample from (#373). 
 
 
 # dials 1.3.0

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -132,6 +132,19 @@ new_quant_param <- function(type = c("double", "integer"),
 
   check_inclusive(inclusive, call = call)
 
+  if (type == "integer" && !any(is_unknown(range))) {
+    range_of_2_consecutive_values <- identical(range[[1]] + 1L, range[[2]])
+    if (range_of_2_consecutive_values) {
+      if (!all(inclusive)) {
+        cli::cli_abort(
+          "{.arg inclusive} must be {.code c(TRUE, TRUE)} when the {.arg range} 
+          only covers two consecutive values.",
+          call = call
+        )
+      }
+    }
+  }
+
   if (!is.null(trans) && !is.trans(trans)) {
     cli::cli_abort(
       c(

--- a/tests/testthat/_snaps/constructors.md
+++ b/tests/testthat/_snaps/constructors.md
@@ -105,6 +105,24 @@
       Error:
       ! `finalize` must be a function or `NULL`, not the string "not a function or NULL".
 
+# integer parameter: compatibility of `inclusive` and `range` (#373)
+
+    Code
+      new_quant_param(type = "integer", range = c(0, 1), inclusive = c(FALSE, FALSE),
+      trans = NULL, label = c(param_non_incl = "some label"), finalize = NULL)
+    Condition
+      Error:
+      ! `inclusive` must be `c(TRUE, TRUE)` when the `range` only covers two consecutive values.
+
+---
+
+    Code
+      new_quant_param(type = "integer", range = c(0, 1), inclusive = c(FALSE, TRUE),
+      trans = NULL, label = c(param_non_incl = "some label"), finalize = NULL)
+    Condition
+      Error:
+      ! `inclusive` must be `c(TRUE, TRUE)` when the `range` only covers two consecutive values.
+
 # bad args to range_validate
 
     Code

--- a/tests/testthat/test-constructors.R
+++ b/tests/testthat/test-constructors.R
@@ -59,6 +59,41 @@ test_that("quantitative parameter object creation - bad args", {
   )
 })
 
+test_that("integer parameter: compatibility of `inclusive` and `range` (#373)", {
+  # if range covers only two consecutive integer values,
+  # `inclusive = c(FALSE, FALSE)` would leave no values to sample from
+  # and `inclusive = c(FALSE, TRUE)` would leave only one value
+  expect_snapshot(error = TRUE, {
+    new_quant_param(
+      type = "integer",
+      range = c(0, 1),
+      inclusive = c(FALSE, FALSE),
+      trans = NULL,
+      label = c(param_non_incl = "some label"),
+      finalize = NULL
+    )
+  })
+  expect_snapshot(error = TRUE, {
+    new_quant_param(
+      type = "integer",
+      range = c(0, 1),
+      inclusive = c(FALSE, TRUE),
+      trans = NULL,
+      label = c(param_non_incl = "some label"),
+      finalize = NULL
+    )
+  })
+  expect_no_error({
+    new_quant_param(
+      type = "integer",
+      range = c(0, 1),
+      inclusive = c(TRUE, TRUE),
+      trans = NULL,
+      label = c(param_non_incl = "some label"),
+      finalize = NULL
+    )
+  })
+})
 
 test_that("bad args to range_validate", {
   expect_snapshot(


### PR DESCRIPTION
closes #373