### PR TITLE
Constructors fill in missing label

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@
 
 * For space-filling designs for $p$ parameters, there is a higher likelihood of finding a space-filling design for `1 < size <= p`. Also, single-point designs now default to a random grid (#363).
 
+* The constructors, `new_*_parameter()`, now label unlabeled parameter (i.e., constructed with `label = NULL`) as such (#349).
+
 ## Breaking changes
 
 * The `grid_*()` functions now error instead of warn when provided with the wrong argument to control the grid size. So `grid_space_filling()`, `grid_random()`, `grid_max_entropy()`, and `grid_latin_hypercube()` now error if used with a `levels` argument and `grid_regular()` now errors if used with a `size` argument (#368).

--- a/R/constructors.R
+++ b/R/constructors.R
@@ -32,8 +32,9 @@
 #' If set, these will be used by [value_seq()] and [value_sample()].
 #'
 #' @param label An optional named character string that can be used for
-#' printing and plotting. The name should match the object name (e.g.
-#' `"mtry"`, `"neighbors"`, etc.)
+#' printing and plotting. The name of the label should match the object name 
+#' (e.g., `"mtry"`, `"neighbors"`, etc.). If `NULL`, the parameter will be 
+#' labeled with `"Unlabeled parameter"`.
 #'
 #' @param finalize A function that can be used to set the data-specific
 #' values of a parameter (such as the `range`).
@@ -76,16 +77,18 @@ NULL
 
 #' @export
 #' @rdname new-param
-new_quant_param <- function(type = c("double", "integer"),
-                            range = NULL,
-                            inclusive = NULL,
-                            default = deprecated(),
-                            trans = NULL,
-                            values = NULL,
-                            label = NULL,
-                            finalize = NULL,
-                            ...,
-                            call = caller_env()) {
+new_quant_param <- function(
+  type = c("double", "integer"),
+  range = NULL,
+  inclusive = NULL,
+  default = deprecated(),
+  trans = NULL,
+  values = NULL,
+  label = NULL,
+  finalize = NULL,
+  ...,
+  call = caller_env()
+) {
   if (lifecycle::is_present(default)) {
     lifecycle::deprecate_stop(
       when = "1.1.0",
@@ -156,6 +159,11 @@ new_quant_param <- function(type = c("double", "integer"),
   }
 
   check_label(label, call = call)
+  if (is.null(label)) {
+    label = "Unlabeled parameter"
+    names(label) <- "Unlabeled parameter"
+  }
+
   check_function(finalize, allow_null = TRUE, call = call)
 
   names(range) <- names(inclusive) <- c("lower", "upper")
@@ -189,16 +197,18 @@ new_quant_param <- function(type = c("double", "integer"),
 
 #' @export
 #' @rdname new-param
-new_qual_param <- function(type = c("character", "logical"),
-                           values,
-                           default = deprecated(),
-                           label = NULL,
-                           finalize = NULL,
-                           ...,
-                           call = caller_env()) {
+new_qual_param <- function(
+  type = c("character", "logical"),
+  values,
+  default = deprecated(),
+  label = NULL,
+  finalize = NULL,
+  ...,
+  call = caller_env()
+) {
   if (lifecycle::is_present(default)) {
     lifecycle::deprecate_stop(
-      when = "1.1.0", 
+      when = "1.1.0",
       what = "new_qual_param(default)"
     )
   }
@@ -210,7 +220,13 @@ new_qual_param <- function(type = c("character", "logical"),
     "logical" = check_logical(values, call = call),
     "character" = check_character(values, call = call)
   )
+
   check_label(label, call = call)
+  if (is.null(label)) {
+    label = "Unlabeled parameter"
+    names(label) <- "Unlabeled parameter"
+  }
+
   check_function(finalize, allow_null = TRUE, call = call)
 
   res <- list(

--- a/man/new-param.Rd
+++ b/man/new-param.Rd
@@ -58,8 +58,9 @@ parameters, this can be used as an alternative to \code{range} and \code{inclusi
 If set, these will be used by \code{\link[=value_seq]{value_seq()}} and \code{\link[=value_sample]{value_sample()}}.}
 
 \item{label}{An optional named character string that can be used for
-printing and plotting. The name should match the object name (e.g.
-\code{"mtry"}, \code{"neighbors"}, etc.)}
+printing and plotting. The name of the label should match the object name
+(e.g., \code{"mtry"}, \code{"neighbors"}, etc.). If \code{NULL}, the parameter will be
+labeled with \code{"Unlabeled parameter"}.}
 
 \item{finalize}{A function that can be used to set the data-specific
 values of a parameter (such as the \code{range}).}


### PR DESCRIPTION
closes #349 

Some notes for github archeology:

I thought about using `rlang::caller_call() %>% rlang::call_name()` to get to what the parameter is called and use it to fill the _name_ of the label and to check the requirement/strong suggestion in the docs of 
> The name should match the object name (e.g. `"mtry"`, `"neighbors"`, etc.) 

Checking that requirement doesn't play nicely with our pattern of reconstructing the parameter object when eg setting the range via `range_set()`. I bumped into a bunch of little things while trying that out which left me with the impression that reaching for the caller name is trying to be too clever for our own good here. 
