### PR TITLE
Clean up `dials::` namespacing

### DIFF
--- a/R/param_all_neighbors.R
+++ b/R/param_all_neighbors.R
@@ -7,7 +7,7 @@
 #' all_neighbors()
 #' @export
 all_neighbors <- function(values = c(TRUE, FALSE)) {
-  dials::new_qual_param(
+  new_qual_param(
     type = "logical",
     values = values,
     label = c(all_neighbors = "All Neighbors"),

--- a/R/param_engine_partykit.R
+++ b/R/param_engine_partykit.R
@@ -16,7 +16,7 @@
 #' corresponds to `1 - {p-value}`.
 #' @export
 conditional_min_criterion <- function(range = c(1.386294, 15), trans = scales::transform_logit()) {
-  dials::new_quant_param(
+  new_quant_param(
     type = "double",
     range = range,
     inclusive = c(TRUE, TRUE),
@@ -32,7 +32,7 @@ values_test_type <- c("Bonferroni", "MonteCarlo", "Univariate", "Teststatistic")
 #' @export
 #' @rdname conditional_min_criterion
 conditional_test_type <- function(values = values_test_type) {
-  dials::new_qual_param(
+  new_qual_param(
     type = "character",
     values = values,
     label = c(conditional_test_type = "Splitting Function Test Type"),
@@ -47,7 +47,7 @@ values_test_statistic <- c("quadratic", "maximum")
 #' @export
 #' @rdname conditional_min_criterion
 conditional_test_statistic <- function(values = values_test_statistic) {
-  dials::new_qual_param(
+  new_qual_param(
     type = "character",
     values = values,
     label = c(conditional_test_statistic = "Splitting Function Test Statistic"),

--- a/R/param_engine_sda.R
+++ b/R/param_engine_sda.R
@@ -21,7 +21,7 @@
 #'
 #' @export
 shrinkage_correlation <- function(range = c(0, 1), trans = NULL) {
-  dials::new_quant_param(
+  new_quant_param(
     type = "double",
     range = range,
     inclusive = c(TRUE, TRUE),
@@ -33,7 +33,7 @@ shrinkage_correlation <- function(range = c(0, 1), trans = NULL) {
 #' @export
 #' @rdname shrinkage_correlation
 shrinkage_variance <- function(range = c(0, 1), trans = NULL) {
-  dials::new_quant_param(
+  new_quant_param(
     type = "double",
     range = range,
     inclusive = c(TRUE, TRUE),
@@ -45,7 +45,7 @@ shrinkage_variance <- function(range = c(0, 1), trans = NULL) {
 #' @export
 #' @rdname shrinkage_correlation
 shrinkage_frequencies <- function(range = c(0, 1), trans = NULL) {
-  dials::new_quant_param(
+  new_quant_param(
     type = "double",
     range = range,
     inclusive = c(TRUE, TRUE),

--- a/R/param_mtry_prop.R
+++ b/R/param_mtry_prop.R
@@ -36,7 +36,7 @@
 #'
 #' @export
 mtry_prop <- function(range = c(0.1, 1), trans = NULL) {
-  dials::new_quant_param(
+  new_quant_param(
     type = "double",
     range = range,
     inclusive = c(TRUE, TRUE),

--- a/R/param_num_tokens.R
+++ b/R/param_num_tokens.R
@@ -7,7 +7,7 @@
 #' num_tokens()
 #' @export
 num_tokens <- function(range = c(1, 3), trans = NULL) {
-  dials::new_quant_param(
+  new_quant_param(
     type = "integer",
     range = range,
     inclusive = c(TRUE, TRUE),


### PR DESCRIPTION
probably a leftover when developing the parameter objects in parsnip and friends first