### PR TITLE
Enforce empty dots for `parameters.list()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@
 
 * The constructors, `new_*_parameter()`, now label unlabeled parameter (i.e., constructed with `label = NULL`) as such (#349).
 
+* `parameters.list()` now enforces the unused ellipsis to be empty (#378).
+
 ## Breaking changes
 
 * The `grid_*()` functions now error instead of warn when provided with the wrong argument to control the grid size. So `grid_space_filling()`, `grid_random()`, `grid_max_entropy()`, and `grid_latin_hypercube()` now error if used with a `levels` argument and `grid_regular()` now errors if used with a `size` argument (#368).

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -29,11 +29,13 @@ parameters.param <- function(x, ...) {
 #' @export
 #' @rdname parameters
 parameters.list <- function(x, ...) {
+  check_dots_empty()
+
   elem_param <- purrr::map_lgl(x, inherits, "param")
   if (any(!elem_param)) {
     cli::cli_abort("The objects should all be {.cls param} objects.")
   }
-  elem_name <- purrr::map_chr(x, ~ names(.x$label))
+  elem_name <- purrr::map_chr(x, ~names(.x$label))
   elem_id <- names(x)
   if (length(elem_id) == 0) {
     elem_id <- elem_name


### PR DESCRIPTION
revdeps are clean