### PR TITLE
Fix broken cover image link (Star Trek)

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -33,7 +33,7 @@ This package contains _infrastructure_ to create and manage values of tuning par
 
 The name reflects the idea that tuning predictive models can be like turning a set of dials on a complex machine under duress. 
 
-<img src="http://tos.trekcore.com/hd/albums/1x04hd/thenakedtimehd1013.jpg" width="576" alt="two Star Trek characters in front of a machine with many dials, lights, and buttons">
+<img src="https://tos.trekcore.com/gallery/albums/screencaps/season1/106-naked-time/naked-time-br-604.jpg" width="576" alt="two Star Trek characters in front of a machine with many dials, lights, and buttons">
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ tuning parameters for the tidymodels packages. If you are looking for
 The name reflects the idea that tuning predictive models can be like
 turning a set of dials on a complex machine under duress.
 
-<img src="http://tos.trekcore.com/hd/albums/1x04hd/thenakedtimehd1013.jpg" width="576" alt="two Star Trek characters in front of a machine with many dials, lights, and buttons">
+<img src="https://tos.trekcore.com/gallery/albums/screencaps/season1/106-naked-time/naked-time-br-604.jpg" width="576" alt="two Star Trek characters in front of a machine with many dials, lights, and buttons">
 
 ## Installation
 


### PR DESCRIPTION
Hello,

It looks like the cover image on the home page (https://dials.tidymodels.org/) and the README at GitHub repo is broken.  
It was hot-linked to the Star Trek site (`tos.trekcore.com`), but the image has been relocated.
https://github.com/tidymodels/dials/blob/a9eceb61ad4bc938b73c0e4ce102b853802eb61f/README.Rmd#L36

The image itself is from the season 1, episode 4 ("The Naked Time").
A wayback snapshot exists: https://web.archive.org/web/20220807053202/https://tos.trekcore.com/hd/albums/1x04hd/thenakedtimehd1013.jpg

This PR replaces the dead TrekCore image URL with a working link.

It might be more robust to store the image file in this repo, but I'm unsure about the copyright, so I just fixed the link.

🖖