### PR TITLE
spellcheck name of tested function

### DIFF
--- a/tests/testthat/_snaps/parameters.md
+++ b/tests/testthat/_snaps/parameters.md
@@ -1,4 +1,4 @@
-# parameters_const() input checks
+# parameters_constr() input checks
 
     Code
       parameters_constr(name = 2)

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -1,4 +1,4 @@
-test_that("parameters_const() input checks", {
+test_that("parameters_constr() input checks", {
   expect_snapshot(error = TRUE, {
     parameters_constr(name = 2)
   })


### PR DESCRIPTION
This is a very minor spellcheck that didn't seem to require an issue. It may be important for search reasons (e.g. the test title is flagged and the developer searches in vain for the keyword if the "whole word" setting is on).