### PR TITLE
Make `grid_space_filling()` work with qual params again

### DIFF
--- a/R/space_filling.R
+++ b/R/space_filling.R
@@ -476,8 +476,6 @@ make_max_entropy_grid <- function(
   param_labs <- map_chr(params, function(x) x$label)
   names(param_labs) <- param_names
 
-  rngs <- map(params, range_get, original = FALSE)
-
   sfd <-
     DiceDesign::dmaxDesign(
       n = size,


### PR DESCRIPTION
Closes #447

The new stricter input checks to `range_get()` mean it only worked for quant parameters - however, we are not using  the ranges anywhere, so I've removed the line.

``` r
library(dials)
#> Loading required package: scales

pset <- parameters(surv_dist())
grid_space_filling(pset, size = 10)
#> # A tibble: 6 × 1
#>   surv_dist  
#>   <chr>      
#> 1 logistic   
#> 2 weibull    
#> 3 loglogistic
#> 4 exponential
#> 5 gaussian   
#> 6 lognormal
```

<sup>Created on 2026-04-09 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>